### PR TITLE
Add support for mod-specific stat files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog v0.3.0](http://keepachangelog.com/en/0.
 
 - Add host information to /info endpoint (request)
 
+### Changed
+
+- Stats are now separate for each mod (#6). Player stats are copied to `fs_game` folder if no stats exist for this mod yet. Keep in mind this also means that level, XP and classes will not be synchronized with the main stats file after this point.
+
 ## [0.6.0] - 2018-12-30
 
 ### Added

--- a/src/Components/Modules/Stats.cpp
+++ b/src/Components/Modules/Stats.cpp
@@ -63,6 +63,17 @@ namespace Components
 		Stats::SendStats();
 	}
 
+	int Stats::SaveStats(char* dest, const char* folder, const char* buffer, size_t length)
+	{
+		const auto fs_game = Game::Dvar_FindVar("fs_game");
+		if (fs_game && fs_game->current.string && strlen(fs_game->current.string) && !strncmp(fs_game->current.string, "mods/", 5))
+		{
+			folder = fs_game->current.string;
+		}
+
+		return Utils::Hook::Call<int(char*, const char*, const char*, size_t)>(0x426450)(dest, folder, buffer, length);
+	}
+
 	Stats::Stats()
 	{
 		// This UIScript should be added in the onClose code of the cac_popup menu,
@@ -91,6 +102,9 @@ namespace Components
 
 		// Don't create stat backup
 		Utils::Hook::Nop(0x402CE6, 2);
+
+		// Write stats to mod folder if a mod is loaded
+		Utils::Hook(0x682F7B, Stats::SaveStats, HOOK_CALL).install()->quick();
 	}
 
 	Stats::~Stats()

--- a/src/Components/Modules/Stats.hpp
+++ b/src/Components/Modules/Stats.hpp
@@ -13,6 +13,7 @@ namespace Components
 	private:
 		static void UpdateClasses(UIScript::Token token);
 		static void SendStats();
+		static int SaveStats(char* dest, const char* folder, const char* buffer, size_t length);
 
 		static int64_t* GetStatsID();
 	};


### PR DESCRIPTION
Add support for mod-specific stat files. This allows mods to update the playerDataDef and allows the creation of classes with custom weapons per mod.