### PR TITLE
Fixes to image decryption check, the game crashing with mods loaded and the latest steam update causing the game to crash

### DIFF
--- a/src/Components/Modules/Zones.cpp
+++ b/src/Components/Modules/Zones.cpp
@@ -2908,23 +2908,13 @@ namespace Components
 
 			// check if file should be skipped
 			auto skipFile = false;
-			if (!strncmp(&file[strlen(file) - 4], ".iwi", 4))
-			{
-				if (readSize > 3 && !memcmp(&fileBuffer[0], "IWi", 3))
-				{
-					skipFile = true;
-				}
-			}
-			else if (strstr(file, "weapons"))
+			if (!strncmp(&file[strlen(file) - 5], ".iwi", 4))
 			{
 				skipFile = true;
 			}
-			else
+			else if (memcmp(&fileBuffer[0], "IWi", 4))
 			{
-				if (readSize > 8 && *reinterpret_cast<std::uint32_t*>(&fileBuffer[4]) == 0xe9c9c447)
-				{
-					skipFile = true;
-				}
+				skipFile = true;
 			}
 			
 			// if the header seems encrypted...

--- a/src/Components/Modules/Zones.cpp
+++ b/src/Components/Modules/Zones.cpp
@@ -2908,11 +2908,12 @@ namespace Components
 
 			// check if file should be skipped
 			auto skipFile = false;
-			if (!strncmp(&file[strlen(file) - 5], ".iwi", 4))
+
+			if (strlen(file) > 5 && ((strncmp(&file[strlen(file) - 4], ".iwi", 4) != 0)))
 			{
 				skipFile = true;
 			}
-			else if (memcmp(&fileBuffer[0], "IWi", 4))
+			else if (readSize >= 3 && (!memcmp(&fileBuffer[0], "IWi", 3)))
 			{
 				skipFile = true;
 			}

--- a/src/Steam/Proxy.cpp
+++ b/src/Steam/Proxy.cpp
@@ -175,11 +175,11 @@ namespace Steam
 		size_t expectedParams = Proxy::ClientUser.paramSize("SpawnProcess");
 		if (expectedParams == 40) // Release
 		{
-			Proxy::ClientUser.invoke<bool>("SpawnProcess", ourPath, cmdline.data(), 0, ourDirectory, gameID.bits, mod.data(), Proxy::AppId, 0, 0);
+			Proxy::ClientUser.invoke("SpawnProcess", ourPath, cmdline.data(), ourDirectory, gameID.bits, mod.data(), Proxy::AppId, 0, 0);
 		}
 		else if (expectedParams == 36) // Beta
 		{
-			Proxy::ClientUser.invoke<bool>("SpawnProcess", ourPath, cmdline.data(), 0, ourDirectory, gameID.bits, mod.data(), 0, 0);
+			Proxy::ClientUser.invoke("SpawnProcess", ourPath, cmdline.data(), ourDirectory, gameID.bits, mod.data(), Proxy::AppId, 0, 0);
 		}
 		else if (expectedParams == 48) // Legacy, expects VAC blob
 		{

--- a/src/Steam/Proxy.cpp
+++ b/src/Steam/Proxy.cpp
@@ -175,11 +175,11 @@ namespace Steam
 		size_t expectedParams = Proxy::ClientUser.paramSize("SpawnProcess");
 		if (expectedParams == 40) // Release
 		{
-			Proxy::ClientUser.invoke("SpawnProcess", ourPath, cmdline.data(), ourDirectory, gameID.bits, mod.data(), Proxy::AppId, 0, 0);
+			Proxy::ClientUser.invoke<bool>("SpawnProcess", ourPath, cmdline.data(), ourDirectory, gameID.bits, mod.data(), Proxy::AppId, 0, 0);
 		}
 		else if (expectedParams == 36) // Beta
 		{
-			Proxy::ClientUser.invoke("SpawnProcess", ourPath, cmdline.data(), ourDirectory, gameID.bits, mod.data(), Proxy::AppId, 0, 0);
+			Proxy::ClientUser.invoke<bool>("SpawnProcess", ourPath, cmdline.data(), ourDirectory, gameID.bits, mod.data(), Proxy::AppId, 0, 0);
 		}
 		else if (expectedParams == 48) // Legacy, expects VAC blob
 		{


### PR DESCRIPTION
- Fix for the game trying to decrypt all read files instead of just encrypted images, also fixes a crash when loading mods due to the game trying to decrypt the gsc files.

- Ugly fix for the game crashing with the latest version of steam (credits to IceNinjaman).