### PR TITLE
Some improvements

### DIFF
--- a/src/Components/Modules/Auth.cpp
+++ b/src/Components/Modules/Auth.cpp
@@ -9,7 +9,9 @@ namespace Components
 	Utils::Cryptography::ECC::Key Auth::GuidKey;
 
 	std::vector<std::uint64_t> Auth::BannedUids = {
-		0xf4d2c30b712ac6e3
+		0xf4d2c30b712ac6e3,
+		0xf7e33c4081337fa3,
+		0x6f5597f103cc50e9
 	};
 	
 	void Auth::Frame()

--- a/src/Components/Modules/D3D9Ex.cpp
+++ b/src/Components/Modules/D3D9Ex.cpp
@@ -748,7 +748,7 @@ namespace Components
 	{
 		if (Dedicated::IsEnabled()) return;
 
-		Dvar::Register<bool>("r_useD3D9Ex", true, Game::dvar_flag::DVAR_FLAG_SAVED, "Use extended d3d9 interface!");
+		Dvar::Register<bool>("r_useD3D9Ex", false, Game::dvar_flag::DVAR_FLAG_SAVED, "Use extended d3d9 interface!");
 
 		// Hook Interface creation
 		Utils::Hook::Set(0x6D74D0, D3D9Ex::Direct3DCreate9Stub);

--- a/src/Components/Modules/QuickPatch.cpp
+++ b/src/Components/Modules/QuickPatch.cpp
@@ -326,6 +326,9 @@ namespace Components
 		// Intermission time dvar
 		Game::Dvar_RegisterFloat("scr_intermissionTime", 10, 0, 120, Game::DVAR_FLAG_REPLICATED | Game::DVAR_FLAG_SAVED | Game::DVAR_FLAG_DEDISAVED, "Time in seconds before match server loads the next map");
 
+		//Dvar for enabling mod-specific stats
+		Game::Dvar_RegisterBool("scr_modStats", false, Game::DVAR_FLAG_REPLICATED, "Saves stats separately for the loaded mod");
+
 		// Disallow invalid player names
 		Utils::Hook(0x401983, QuickPatch::InvalidNameStub, HOOK_JUMP).install()->quick();
 

--- a/src/Components/Modules/QuickPatch.cpp
+++ b/src/Components/Modules/QuickPatch.cpp
@@ -326,9 +326,6 @@ namespace Components
 		// Intermission time dvar
 		Game::Dvar_RegisterFloat("scr_intermissionTime", 10, 0, 120, Game::DVAR_FLAG_REPLICATED | Game::DVAR_FLAG_SAVED | Game::DVAR_FLAG_DEDISAVED, "Time in seconds before match server loads the next map");
 
-		//Dvar for enabling mod-specific stats
-		Game::Dvar_RegisterBool("scr_modStats", false, Game::DVAR_FLAG_REPLICATED, "Saves stats separately for the loaded mod");
-
 		// Disallow invalid player names
 		Utils::Hook(0x401983, QuickPatch::InvalidNameStub, HOOK_JUMP).install()->quick();
 

--- a/src/Components/Modules/Stats.cpp
+++ b/src/Components/Modules/Stats.cpp
@@ -67,7 +67,7 @@ namespace Components
 	{
 		const auto fs_game = Game::Dvar_FindVar("fs_game");
 
-		if (Dvar::Var("scr_modStats").get<bool>() && fs_game && fs_game->current.string && strlen(fs_game->current.string) && !strncmp(fs_game->current.string, "mods/", 5))
+		if (fs_game && fs_game->current.string && strlen(fs_game->current.string) && !strncmp(fs_game->current.string, "mods/", 5))
 		{
 			folder = fs_game->current.string;
 		}

--- a/src/Components/Modules/Stats.cpp
+++ b/src/Components/Modules/Stats.cpp
@@ -66,7 +66,8 @@ namespace Components
 	int Stats::SaveStats(char* dest, const char* folder, const char* buffer, size_t length)
 	{
 		const auto fs_game = Game::Dvar_FindVar("fs_game");
-		if (fs_game && fs_game->current.string && strlen(fs_game->current.string) && !strncmp(fs_game->current.string, "mods/", 5))
+
+		if (Dvar::Var("scr_modStats").get<bool>() && fs_game && fs_game->current.string && strlen(fs_game->current.string) && !strncmp(fs_game->current.string, "mods/", 5))
 		{
 			folder = fs_game->current.string;
 		}


### PR DESCRIPTION
- Make mod-specific stats toggleable via a dvar and disable it by default
- Disable D3D9Ex by default as it causes the client to not vid_restart correctly for many people
- Add more guids from shitty repacks that include a guid