### PR TITLE
Update ZoneBuilder.cpp for building CoDOL Maps

### DIFF
--- a/src/Components/Modules/ZoneBuilder.cpp
+++ b/src/Components/Modules/ZoneBuilder.cpp
@@ -259,29 +259,6 @@ namespace Components
 			return false;
 		}
 
-		//patch for codol maps dumped with zonetool, the FF version is changed, so the sortKey hack in AssetHandler::ModifyAsset won't work
-		if (type == Game::XAssetType::ASSET_TYPE_GFXWORLD)
-		{
-			if (assetHeader.gfxWorld->sortKeyDistortion == 44)
-			{
-				assetHeader.gfxWorld->sortKeyDistortion = 43;
-			}
-			//Absolutely necessary patch for later codol maps. prevents player models from glowing ridiculously 
-			if (assetHeader.gfxWorld->heroOnlyLightCount > 0)
-			{
-				Logger::Print("Fixing heroOnlyLightCount...\n");
-				assetHeader.gfxWorld->heroOnlyLightCount = 0;
-			}
-		}
-		//likewise if material's sortKey is 44, it needs to be changed to 43.
-		if (type == Game::XAssetType::ASSET_TYPE_MATERIAL)
-		{
-			if (assetHeader.material->info.sortKey == 44)
-			{
-				assetHeader.material->info.sortKey = 43;
-			}
-		}
-
 		Game::XAsset asset;
 		asset.type = type;
 		asset.header = assetHeader;

--- a/src/Components/Modules/ZoneBuilder.cpp
+++ b/src/Components/Modules/ZoneBuilder.cpp
@@ -259,6 +259,23 @@ namespace Components
 			return false;
 		}
 
+		//patch for codol maps dumped with zonetool, the FF version is changed, so the sortKey hack in AssetHandler::ModifyAsset won't work
+		if (type == Game::XAssetType::ASSET_TYPE_GFXWORLD)
+		{
+			if (assetHeader.gfxWorld->sortKeyDistortion == 44)
+			{
+				assetHeader.gfxWorld->sortKeyDistortion = 43;
+			}
+		}
+		//likewise if material's sortKey is 44, it needs to be changed to 43.
+		if (type == Game::XAssetType::ASSET_TYPE_MATERIAL)
+		{
+			if (assetHeader.material->info.sortKey == 44)
+			{
+				assetHeader.material->info.sortKey = 43;
+			}
+		}
+
 		Game::XAsset asset;
 		asset.type = type;
 		asset.header = assetHeader;

--- a/src/Components/Modules/ZoneBuilder.cpp
+++ b/src/Components/Modules/ZoneBuilder.cpp
@@ -266,6 +266,12 @@ namespace Components
 			{
 				assetHeader.gfxWorld->sortKeyDistortion = 43;
 			}
+			//Absolutely necessary patch for later codol maps. prevents player models from glowing ridiculously 
+			if (assetHeader.gfxWorld->heroOnlyLightCount > 0)
+			{
+				Logger::Print("Fixing heroOnlyLightCount...\n");
+				assetHeader.gfxWorld->heroOnlyLightCount = 0;
+			}
 		}
 		//likewise if material's sortKey is 44, it needs to be changed to 43.
 		if (type == Game::XAssetType::ASSET_TYPE_MATERIAL)

--- a/src/Components/Modules/Zones.cpp
+++ b/src/Components/Modules/Zones.cpp
@@ -1929,9 +1929,12 @@ namespace Components
 			AssetHandler::Relocate(buffer + 0x20, buffer + 0x18, 0x30);
 			AssetHandler::Relocate(buffer + 0x51, buffer + 0x48, 5);
 			AssetHandler::Relocate(buffer + 0x58, buffer + 0x50, 0x10);
-
+			
+			Game::Material* material = reinterpret_cast<Game::Material*>(buffer);
 			// fix statebit
-			reinterpret_cast<Game::Material*>(buffer)->stateBitsEntry[47] = codol_material[0x50];
+			material->stateBitsEntry[47] = codol_material[0x50];
+			//check to fix distortion
+			if (material->info.sortKey == 44) material->info.sortKey = 43;
 		}
 		else if (Zones::ZoneVersion >= 359)
 		{
@@ -1974,6 +1977,9 @@ namespace Components
 			// Actually, it's not
 			// yes it was lol
 			memcpy(&material->info.drawSurf.packed, material359.drawSurfBegin, 8);
+
+			//adding this here, situation as with later ff versions
+			if (material->info.sortKey == 44) material->info.sortKey = 43;
 
 			memcpy(&material->info.surfaceTypeBits, &material359.drawSurf[0], 6); // copies both surfaceTypeBits and hashIndex
 			//material->drawSurf[8] = material359.drawSurf[0];
@@ -2025,6 +2031,9 @@ namespace Components
 			int sunDiff = 8;	// Stuff that is part of the sunflare we would overwrite
 			std::memmove(buffer + 348 + sunDiff, buffer + 1316 + sunDiff, 280 - sunDiff);
 			AssetHandler::Relocate(buffer + 1316, buffer + 348, 280);
+
+			//all codol zones are like this pretty certain
+			reinterpret_cast<Game::GfxWorld*>(buffer)->sortKeyDistortion = 43;
 		}
 
 		return result;


### PR DESCRIPTION
AssetHandler::ModifyAsset checks the zone version and then applies a patch, this won't work with maps compiled with zonebuilder because the ff version is the same as other iw4 zones.  Therefore the sortkey needs to be fixed when the map gets built instead of at runtime.
