### PR TITLE
Fix typo in steam mod

### DIFF
--- a/src/Components/Modules/ServerList.cpp
+++ b/src/Components/Modules/ServerList.cpp
@@ -17,8 +17,8 @@
 
 namespace Components
 {
-	bool ServerList::SortAsc = true;
-	int ServerList::SortKey = static_cast<std::underlying_type_t<Column>>(Column::Ping);
+	bool ServerList::SortAsc = false;
+	int ServerList::SortKey = static_cast<std::underlying_type_t<Column>>(Column::Players);
 
 	unsigned int ServerList::CurrentServer = 0;
 	ServerList::Container ServerList::RefreshContainer;

--- a/src/Steam/Steam.cpp
+++ b/src/Steam/Steam.cpp
@@ -130,7 +130,7 @@ namespace Steam
 			}
 			else
 			{
-				Proxy::SetMod("IW4y: Modern Warfare 2");
+				Proxy::SetMod("IW4x: Modern Warfare 2");
 				Proxy::RunGame();
 			}
 


### PR DESCRIPTION
_Someone_ left a **y** where an **x** should be
