### PR TITLE
Sort ServerList by players

### DIFF
--- a/src/Components/Modules/ServerList.cpp
+++ b/src/Components/Modules/ServerList.cpp
@@ -17,8 +17,8 @@
 
 namespace Components
 {
-	bool ServerList::SortAsc = true;
-	int ServerList::SortKey = static_cast<std::underlying_type_t<Column>>(Column::Ping);
+	bool ServerList::SortAsc = false;
+	int ServerList::SortKey = static_cast<std::underlying_type_t<Column>>(Column::Players);
 
 	unsigned int ServerList::CurrentServer = 0;
 	ServerList::Container ServerList::RefreshContainer;


### PR DESCRIPTION
Sort ServerList by player count by default, I assume this is whats most useful.
Also referencing the following rawfiles PR this is the better solution in my opinion.
https://github.com/iw4x/iw4x-rawfiles/pull/3