### PR TITLE
Fix typo in steam mod

### DIFF
--- a/src/Steam/Steam.cpp
+++ b/src/Steam/Steam.cpp
@@ -130,7 +130,7 @@ namespace Steam
 			}
 			else
 			{
-				Proxy::SetMod("IW4y: Modern Warfare 2");
+				Proxy::SetMod("IW4x: Modern Warfare 2");
 				Proxy::RunGame();
 			}
 


### PR DESCRIPTION
_Someone_ left a **y** where an **x** should be