### PR TITLE
Ban another guid that got shipped in a repack of the game.

### DIFF
--- a/src/Components/Modules/Auth.cpp
+++ b/src/Components/Modules/Auth.cpp
@@ -21,7 +21,8 @@ namespace Components
 	{
 		0xf4d2c30b712ac6e3,
 		0xf7e33c4081337fa3,
-		0x6f5597f103cc50e9
+		0x6f5597f103cc50e9,
+		0xecd542eee54ffccf
 	};
 
 	bool Auth::HasAccessToReservedSlot;

--- a/src/Components/Modules/Auth.cpp
+++ b/src/Components/Modules/Auth.cpp
@@ -22,7 +22,7 @@ namespace Components
 		0xf4d2c30b712ac6e3,
 		0xf7e33c4081337fa3,
 		0x6f5597f103cc50e9,
-		0xecd542eee54ffccf
+		0xecd542eee54ffccf,
 	};
 
 	bool Auth::HasAccessToReservedSlot;


### PR DESCRIPTION
**What does this PR do?**

This PR extends the list of banned UIDs by one.

**How does this PR change IW4x's behaviour?**

It forces the players using this shared ID to generate a new and unique one.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Mention any [related issues](https://github.com/XLabsProject/iw4x-client/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/XLabsProject/iw4x-client/blob/master/CODESTYLE.md)
- [x] Minimize the number of commits
