### PR TITLE
Compatibility and improvements for Bot Warfare

### DIFF
--- a/src/Components/Modules/Bots.cpp
+++ b/src/Components/Modules/Bots.cpp
@@ -301,8 +301,10 @@ namespace Components
 			return;
 		}
 
+		auto clientNum = cl - Game::svs_clients;
+
 		// Keep test client functionality
-		if (!g_botai[cl - Game::svs_clients].active)
+		if (!g_botai[clientNum].active)
 		{
 			Game::SV_BotUserMove(cl);
 			return;
@@ -313,11 +315,11 @@ namespace Components
 
 		userCmd.serverTime = *Game::svs_time;
 
-		userCmd.buttons = g_botai[cl - Game::svs_clients].buttons;
-		userCmd.forwardmove = g_botai[cl - Game::svs_clients].forward;
-		userCmd.rightmove = g_botai[cl - Game::svs_clients].right;
-		userCmd.weapon = g_botai[cl - Game::svs_clients].weapon;
-		userCmd.primaryWeaponForAltMode = g_botai[cl - Game::svs_clients].lastAltWeapon;
+		userCmd.buttons = g_botai[clientNum].buttons;
+		userCmd.forwardmove = g_botai[clientNum].forward;
+		userCmd.rightmove = g_botai[clientNum].right;
+		userCmd.weapon = g_botai[clientNum].weapon;
+		userCmd.primaryWeaponForAltMode = g_botai[clientNum].lastAltWeapon;
 
 		userCmd.angles[0] = ANGLE2SHORT((cl->gentity->client->ps.viewangles[0] - cl->gentity->client->ps.delta_angles[0]));
 		userCmd.angles[1] = ANGLE2SHORT((cl->gentity->client->ps.viewangles[1] - cl->gentity->client->ps.delta_angles[1]));
@@ -350,21 +352,21 @@ namespace Components
 
 			auto* def = Game::BG_GetWeaponCompleteDef(iWeaponIndex);
 
-			if (def->weapDef->inventoryType == Game::WEAPINVENTORY_ALTMODE)
+			if (def && def->weapDef->inventoryType == Game::WEAPINVENTORY_ALTMODE)
 			{
 				auto* ps = &Game::g_entities[clientNum].client->ps;
-				auto num_weaps = Game::BG_GetNumWeapons();
+				auto numWeaps = Game::BG_GetNumWeapons();
 
-				for (auto i = 1u; i < num_weaps; i++)
+				for (auto i = 1u; i < numWeaps; i++)
 				{
 					if (!Game::BG_PlayerHasWeapon(ps, i))
 					{
 						continue;
 					}
 
-					auto* this_def = Game::BG_GetWeaponCompleteDef(i);
+					auto* thisDef = Game::BG_GetWeaponCompleteDef(i);
 
-					if (this_def->altWeaponIndex != iWeaponIndex)
+					if (!thisDef || thisDef->altWeaponIndex != iWeaponIndex)
 					{
 						continue;
 					}
@@ -523,7 +525,7 @@ namespace Components
 
 		Utils::Hook(0x441B80, G_SelectWeaponIndex_Hk, HOOK_JUMP).install()->quick();
 
-		// fix bots using objects
+		// fix bots using objects (SV_IsClientBot)
 		Utils::Hook(0x4D79C5, Player_UpdateActivate_stub, HOOK_CALL).install()->quick();
 
 		Utils::Hook(0x459654, SV_GetClientPing_Hk, HOOK_CALL).install()->quick();

--- a/src/Components/Modules/Bots.cpp
+++ b/src/Components/Modules/Bots.cpp
@@ -28,6 +28,8 @@ namespace Components
 		std::int8_t right;
 		std::uint16_t weapon;
 		std::uint16_t lastAltWeapon;
+		std::uint8_t meleeDist;
+		float meleeYaw;
 		bool active;
 	};
 
@@ -292,6 +294,23 @@ namespace Components
 			g_botai[entref.entnum].right = static_cast<int8_t>(rightInt);
 			g_botai[entref.entnum].active = true;
 		});
+
+		GSC::Script::AddMethod("BotMeleeParams", [](const Game::scr_entref_t entref) // Usage: <bot> BotMeleeParams(<float>, <float>);
+		{
+			const auto* ent = GSC::Script::Scr_GetPlayerEntity(entref);
+			if (!Game::SV_IsTestClient(ent->s.number))
+			{
+				Game::Scr_Error("BotMeleeParams: Can only call on a bot!");
+				return;
+			}
+
+			const auto yaw = Game::Scr_GetFloat(0);
+			const auto dist = std::clamp<int>(static_cast<int>(Game::Scr_GetFloat(1)), std::numeric_limits<unsigned char>::min(), std::numeric_limits<unsigned char>::max());
+
+			g_botai[entref.entnum].meleeYaw = yaw;
+			g_botai[entref.entnum].meleeDist = static_cast<int8_t>(dist);
+			g_botai[entref.entnum].active = true;
+		});
 	}
 
 	void Bots::BotAiAction(Game::client_s* cl)
@@ -320,6 +339,8 @@ namespace Components
 		userCmd.rightmove = g_botai[clientNum].right;
 		userCmd.weapon = g_botai[clientNum].weapon;
 		userCmd.primaryWeaponForAltMode = g_botai[clientNum].lastAltWeapon;
+		userCmd.meleeChargeYaw = g_botai[clientNum].meleeYaw;
+		userCmd.meleeChargeDist = g_botai[clientNum].meleeDist;
 
 		userCmd.angles[0] = ANGLE2SHORT((cl->gentity->client->ps.viewangles[0] - cl->gentity->client->ps.delta_angles[0]));
 		userCmd.angles[1] = ANGLE2SHORT((cl->gentity->client->ps.viewangles[1] - cl->gentity->client->ps.delta_angles[1]));

--- a/src/Components/Modules/Bots.hpp
+++ b/src/Components/Modules/Bots.hpp
@@ -32,8 +32,10 @@ namespace Components
 		static void BotAiAction(Game::client_s* cl);
 		static void SV_BotUserMove_Hk();
 
-		static void G_SelectWeaponIndex(int clientNum, int iWeaponIndex);
+		static void G_SelectWeaponIndex(int clientNum, unsigned int iWeaponIndex);
 		static void G_SelectWeaponIndex_Hk();
+
+		static bool Player_UpdateActivate_stub(int);
 
 		static int SV_GetClientPing_Hk(int clientNum);
 

--- a/src/Components/Modules/GSC/IO.cpp
+++ b/src/Components/Modules/GSC/IO.cpp
@@ -93,7 +93,7 @@ namespace Components::GSC
 			return;
 		}
 
-		char line[65536]{};
+		char line[1024]{};
 		if (std::fgets(line, sizeof(line), openScriptIOFileHandle) != nullptr)
 		{
 			Game::Scr_AddString(line);

--- a/src/Components/Modules/GSC/IO.cpp
+++ b/src/Components/Modules/GSC/IO.cpp
@@ -30,12 +30,20 @@ namespace Components::GSC
 	std::filesystem::path IO::BuildPath(const char* path)
 	{
 		const std::filesystem::path fsGame = (*Game::fs_gameDirVar)->current.string;
-		if (!fsGame.empty())
+
+		// check if we need to append scriptdata folder, for backwards compat
+		std::string spath = path;
+		if (!spath.starts_with("scriptdata/") && !spath.starts_with("scriptdata\\"))
 		{
-			return fsGame / "scriptdata"s / path;
+			spath = "scriptdata/" + spath;
 		}
 
-		return DefaultDestPath / "scriptdata"s / path;
+		if (!fsGame.empty())
+		{
+			return fsGame / spath;
+		}
+
+		return DefaultDestPath / spath;
 	}
 
 	void IO::GScr_OpenFile()
@@ -85,7 +93,7 @@ namespace Components::GSC
 			return;
 		}
 
-		char line[1024]{};
+		char line[65536]{};
 		if (std::fgets(line, sizeof(line), openScriptIOFileHandle) != nullptr)
 		{
 			Game::Scr_AddString(line);
@@ -154,7 +162,7 @@ namespace Components::GSC
 				return;
 			}
 
-			file = file.substr(0, 1024 - 1); // 1024 is the max string size for the SL system
+			file = file.substr(0, (1 << 16) - 1); // 65535 is the max string size for the SL system
 			Game::Scr_AddString(file.data());
 		});
 

--- a/src/Components/Modules/GSC/IO.cpp
+++ b/src/Components/Modules/GSC/IO.cpp
@@ -33,9 +33,9 @@ namespace Components::GSC
 
 		// check if we need to append scriptdata folder, for backwards compat
 		std::string spath = path;
-		if (!spath.starts_with("scriptdata/") && !spath.starts_with("scriptdata\\"))
+		if (!spath.starts_with(Game::SCRIPTDATA_DIR + "/"s) && !spath.starts_with(Game::SCRIPTDATA_DIR + "\\"s))
 		{
-			spath = "scriptdata/" + spath;
+			spath = Game::SCRIPTDATA_DIR + "/"s + spath;
 		}
 
 		if (!fsGame.empty())

--- a/src/Components/Modules/GSC/ScriptStorage.cpp
+++ b/src/Components/Modules/GSC/ScriptStorage.cpp
@@ -84,12 +84,12 @@ namespace Components::GSC
 
 			const nlohmann::json json = Data;
 
-			FileSystem::FileWriter("scriptdata/scriptstorage.json").write(json.dump());
+			FileSystem::FileWriter(Game::SCRIPTDATA_DIR + "/scriptstorage.json"s).write(json.dump());
 		});
 
 		Script::AddFunction("StorageLoad", [] // gsc: StorageLoad();
 		{
-			FileSystem::File storageFile("scriptdata/scriptstorage.json");
+			FileSystem::File storageFile(Game::SCRIPTDATA_DIR + "/scriptstorage.json"s);
 			if (!storageFile.exists())
 			{
 				return;

--- a/src/Game/BothGames.cpp
+++ b/src/Game/BothGames.cpp
@@ -11,4 +11,6 @@ namespace Game
 	BG_IsWeaponValid_t BG_IsWeaponValid = BG_IsWeaponValid_t(0x415BA0);
 	BG_GetEquippedWeaponIndex_t BG_GetEquippedWeaponIndex = BG_GetEquippedWeaponIndex_t(0x4D8BA0);
 	BG_GetEquippedWeaponState_t BG_GetEquippedWeaponState = BG_GetEquippedWeaponState_t(0x4E79E0);
+	BG_PlayerHasWeapon_t BG_PlayerHasWeapon = BG_PlayerHasWeapon_t(0x4AB530);
+	BG_GetWeaponCompleteDef_t BG_GetWeaponCompleteDef = BG_GetWeaponCompleteDef_t(0x44CE00);
 }

--- a/src/Game/BothGames.hpp
+++ b/src/Game/BothGames.hpp
@@ -28,4 +28,10 @@ namespace Game
 
 	typedef PlayerEquippedWeaponState*(*BG_GetEquippedWeaponState_t)(playerState_s* ps, unsigned int weaponIndex);
 	extern BG_GetEquippedWeaponState_t BG_GetEquippedWeaponState;
+
+	typedef int*(*BG_PlayerHasWeapon_t)(playerState_s* ps, unsigned int weaponIndex);
+	extern BG_PlayerHasWeapon_t BG_PlayerHasWeapon;
+
+	typedef Game::WeaponCompleteDef*(*BG_GetWeaponCompleteDef_t)(unsigned int weaponIndex);
+	extern BG_GetWeaponCompleteDef_t BG_GetWeaponCompleteDef;
 }

--- a/src/Game/Script.hpp
+++ b/src/Game/Script.hpp
@@ -221,6 +221,8 @@ namespace Game
 
 	constexpr auto LOCAL_VAR_STACK_SIZE = 64;
 
+	constexpr auto SCRIPTDATA_DIR = "scriptdata";
+
 	extern void IncInParam();
 
 	extern void Scr_AddBool(int value);


### PR DESCRIPTION
**What does this PR do?**

My Bot Warfare mod (https://github.com/ineedbots/iw4_bot_warfare) will be compatible with this client with these changes. Bots will be able to press the Use button on objects, bots will be able to use alt weaponry properly. Added `botMeleeParams` builtin to allow bots to melee lung

**How does this PR change IW4x's behaviour?**

Nothing is breaking.

**Anything else we should know?**

Max SL string length is actually 65535, not 1023, this is a required change for Bot Warfare reading waypoints. "scriptdata/" is NOT added to filepath if it already exists in the argument.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Mention any [related issues](https://github.com/XLabsProject/iw4x-client/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/XLabsProject/iw4x-client/blob/master/CODESTYLE.md)
- [x] Minimize the number of commits
