### PR TITLE
fix: auto-restarting the same map in private match

### DIFF
--- a/src/Components/Modules/MapRotation.cpp
+++ b/src/Components/Modules/MapRotation.cpp
@@ -217,16 +217,17 @@ namespace Components
 
 	bool MapRotation::ShouldRotate()
 	{
-		if (!Dedicated::IsEnabled() && SVDontRotate.get<bool>())
+		if (!Dedicated::IsEnabled() && Dvar::Var("party_host").get<bool>())
 		{
-			Logger::Print(Game::CON_CHANNEL_SERVER, "Not performing map rotation as sv_dontRotate is true\n");
-			SVDontRotate.set(false);
+			Logger::Warning(Game::CON_CHANNEL_SERVER, "Not performing map rotation as we are hosting a party!\n");
+			SVDontRotate.set(true);
 			return false;
 		}
 
-		if (Party::IsEnabled() && Dvar::Var("party_host").get<bool>())
+		if (Dedicated::IsEnabled() && SVDontRotate.get<bool>())
 		{
-			Logger::Warning(Game::CON_CHANNEL_SERVER, "Not performing map rotation as we are hosting a party!\n");
+			Logger::Print(Game::CON_CHANNEL_SERVER, "Not performing map rotation as sv_dontRotate is true\n");
+			SVDontRotate.set(true);
 			return false;
 		}
 


### PR DESCRIPTION
Fixes issue where private matches would map_restart after every game. Players are returned to the lobby instead.

Applies to private matches only. 