### PR TITLE
Feat: Native integration with Fail2Ban for Linux server Hosters

### DIFF
--- a/src/Components/Modules/Auth.cpp
+++ b/src/Components/Modules/Auth.cpp
@@ -144,6 +144,7 @@ namespace Components
 		Proto::Auth::Connect connectData;
 		if (msg->cursize <= 12 || !connectData.ParseFromString(std::string(reinterpret_cast<char*>(&msg->data[12]), msg->cursize - 12)))
 		{
+			Logger::PrintFail2Ban("Failed connect attempt from IP address: {}\n", Network::AdrToString(address));
 			Network::Send(address, "error\nInvalid connect packet!");
 			return;
 		}
@@ -161,6 +162,7 @@ namespace Components
 			}
 			else
 			{
+				Logger::PrintFail2Ban("Failed connect attempt from IP address: {}\n", Network::AdrToString(address));
 				Network::Send(address, "error\nInvalid infostring data!");
 			}
 		}
@@ -170,6 +172,7 @@ namespace Components
 			// Validate proto data
 			if (connectData.signature().empty() || connectData.publickey().empty() || connectData.token().empty() || connectData.infostring().empty())
 			{
+				Logger::PrintFail2Ban("Failed connect attempt from IP address: {}\n", Network::AdrToString(address));
 				Network::Send(address, "error\nInvalid connect data!");
 				return;
 			}
@@ -184,6 +187,7 @@ namespace Components
 			// Ensure there are enough params
 			if (params.size() < 3)
 			{
+				Logger::PrintFail2Ban("Failed connect attempt from IP address: {}\n", Network::AdrToString(address));
 				Network::Send(address, "error\nInvalid connect string!");
 				return;
 			}
@@ -197,6 +201,7 @@ namespace Components
 
 			if (steamId.empty() || challenge.empty())
 			{
+				Logger::PrintFail2Ban("Failed connect attempt from IP address: {}\n", Network::AdrToString(address));
 				Network::Send(address, "error\nInvalid connect data!");
 				return;
 			}

--- a/src/Components/Modules/Logger.hpp
+++ b/src/Components/Modules/Logger.hpp
@@ -18,6 +18,7 @@ namespace Components
 		static void ErrorInternal(Game::errorParm_t error, const std::string_view& fmt, std::format_args&& args);
 		static void PrintErrorInternal(Game::conChannel_t channel, const std::string_view& fmt, std::format_args&& args);
 		static void WarningInternal(Game::conChannel_t channel, const std::string_view& fmt, std::format_args&& args);
+		static void PrintFail2BanInternal(const std::string_view& fmt, std::format_args&& args);
 		static void DebugInternal(const std::string_view& fmt, std::format_args&& args, const std::source_location& loc);
 
 		static void Print(const std::string_view& fmt)
@@ -80,6 +81,18 @@ namespace Components
 			PrintErrorInternal(channel, fmt, std::make_format_args(args...));
 		}
 
+		static void PrintFail2Ban(const std::string_view& fmt)
+		{
+			PrintFail2BanInternal(fmt, std::make_format_args(0));
+		}
+
+		template <typename... Args>
+		static void PrintFail2Ban(const std::string_view& fmt, Args&&... args)
+		{
+			(Utils::String::SanitizeFormatArgs(args), ...);
+			PrintFail2BanInternal(fmt, std::make_format_args(args...));
+		}
+
 		struct FormatWithLocation
 		{
 			std::string_view format;
@@ -114,7 +127,8 @@ namespace Components
 		static std::recursive_mutex LoggingMutex;
 		static std::vector<Network::Address> LoggingAddresses[2];
 
-		static Dvar::Var IW4x_oneLog;
+		static Dvar::Var IW4x_one_log;
+		static Dvar::Var IW4x_fail2ban_location;
 
 		static void(*PipeCallback)(const std::string&);
 

--- a/src/Components/Modules/Network.cpp
+++ b/src/Components/Modules/Network.cpp
@@ -39,6 +39,11 @@ namespace Components
 		return ntohs(this->address.port);
 	}
 
+	unsigned short Network::Address::getPortRaw() const
+	{
+		return this->address.port;
+	}
+
 	void Network::Address::setIP(DWORD ip)
 	{
 		this->address.ip.full = ip;
@@ -149,6 +154,31 @@ namespace Components
 	bool Network::Address::isValid() const noexcept
 	{
 		return (this->getType() != Game::NA_BAD && this->getType() >= Game::NA_BOT && this->getType() <= Game::NA_IP);
+	}
+
+	const char* Network::AdrToString(const Address& a, const bool port)
+	{
+		if (a.getType() == Game::netadrtype_t::NA_LOOPBACK)
+		{
+			return "loopback";
+		}
+
+		if (a.getType() == Game::netadrtype_t::NA_BOT)
+		{
+			return "bot";
+		}
+
+		if (a.getType() == Game::netadrtype_t::NA_IP || a.getType() == Game::netadrtype_t::NA_BROADCAST)
+		{
+			if (a.getPort() && port)
+			{
+				return Utils::String::VA("%u.%u.%u.%u:%u", a.getIP().bytes[0], a.getIP().bytes[1], a.getIP().bytes[2], a.getIP().bytes[3], htons(a.getPortRaw()));
+			}
+
+			return Utils::String::VA("%u.%u.%u.%u", a.getIP().bytes[0], a.getIP().bytes[1], a.getIP().bytes[2], a.getIP().bytes[3]);
+		}
+
+		return "bad";
 	}
 
 	void Network::Send(Game::netsrc_t type, const Address& target, const std::string& data)

--- a/src/Components/Modules/Network.hpp
+++ b/src/Components/Modules/Network.hpp
@@ -22,6 +22,7 @@ namespace Components
 
 			void setPort(unsigned short port);
 			[[nodiscard]] unsigned short getPort() const;
+			[[nodiscard]] unsigned short getPortRaw() const;
 
 			void setIP(DWORD ip);
 			void setIP(Game::netIP_t ip);
@@ -50,6 +51,8 @@ namespace Components
 		using networkRawCallback = std::function<void(Game::netadr_t*, Game::msg_t* msg)>;
 
 		Network();
+
+		static const char* AdrToString(const Address& a, bool port = false);
 
 		static std::uint16_t GetPort();
 		

--- a/src/Components/Modules/RCon.cpp
+++ b/src/Components/Modules/RCon.cpp
@@ -180,7 +180,8 @@ namespace Components
 		const auto pos = data.find_first_of(' ');
 		if (pos == std::string::npos)
 		{
-			Logger::Print(Game::CON_CHANNEL_NETWORK, "Invalid RCon request from {}\n", address.getString());
+			Logger::PrintFail2Ban("Invalid packet from IP address: {}\n", Network::AdrToString(address));
+			Logger::Print(Game::CON_CHANNEL_NETWORK, "Invalid RCon request from {}\n", Network::AdrToString(address));
 			return;
 		}
 
@@ -203,7 +204,8 @@ namespace Components
 
 		if (svPassword != password)
 		{
-			Logger::Print(Game::CON_CHANNEL_NETWORK, "Invalid RCon password sent from {}\n", address.getString());
+			Logger::PrintFail2Ban("Invalid packet from IP address: {}\n", Network::AdrToString(address));
+			Logger::Print(Game::CON_CHANNEL_NETWORK, "Invalid RCon password sent from {}\n", Network::AdrToString(address));
 			return;
 		}
 
@@ -213,7 +215,7 @@ namespace Components
 		if (RConLogRequests.get<bool>())
 #endif
 		{
-			Logger::Print(Game::CON_CHANNEL_NETWORK, "Executing RCon request from {}: {}\n", address.getString(), command);
+			Logger::Print(Game::CON_CHANNEL_NETWORK, "Executing RCon request from {}: {}\n", Network::AdrToString(address), command);
 		}
 
 		Logger::PipeOutput([](const std::string& output)
@@ -318,6 +320,7 @@ namespace Components
 			const auto time = Game::Sys_Milliseconds();
 			if (!IsRateLimitCheckDisabled() && !RateLimitCheck(address, time))
 			{
+				Logger::PrintFail2Ban("Invalid packet from IP address: {}\n", Network::AdrToString(address));
 				return;
 			}
 
@@ -341,6 +344,7 @@ namespace Components
 			const auto time = Game::Sys_Milliseconds();
 			if (!IsRateLimitCheckDisabled() && !RateLimitCheck(address, time))
 			{
+				Logger::PrintFail2Ban("Invalid packet from IP address: {}\n", Network::AdrToString(address));
 				return;
 			}
 
@@ -360,13 +364,15 @@ namespace Components
 			Proto::RCon::Command directive;
 			if (!directive.ParseFromString(data))
 			{
-				Logger::PrintError(Game::CON_CHANNEL_NETWORK, "Unable to parse secure command from {}\n", address.getString());
+				Logger::PrintFail2Ban("Invalid packet from IP address: {}\n", Network::AdrToString(address));
+				Logger::PrintError(Game::CON_CHANNEL_NETWORK, "Unable to parse secure command from {}\n", Network::AdrToString(address));
 				return;
 			}
 
 			if (!Utils::Cryptography::RSA::VerifyMessage(key, directive.command(), directive.signature()))
 			{
-				Logger::PrintError(Game::CON_CHANNEL_NETWORK, "RSA signature verification failed for message from {}\n", address.getString());
+				Logger::PrintFail2Ban("Invalid packet from IP address: {}\n", Network::AdrToString(address));
+				Logger::PrintError(Game::CON_CHANNEL_NETWORK, "RSA signature verification failed for message from {}\n", Network::AdrToString(address));
 				return;
 			}
 

--- a/src/Components/Modules/Security.cpp
+++ b/src/Components/Modules/Security.cpp
@@ -119,6 +119,7 @@ namespace Components
 	{
 		if ((client->reliableSequence - client->reliableAcknowledge) < 0)
 		{
+			Logger::PrintFail2Ban("Invalid packet from IP address: {}\n", Network::AdrToString(client->header.netchan.remoteAddress));
 			Logger::Print(Game::CON_CHANNEL_NETWORK, "Negative reliableAcknowledge from {} - cl->reliableSequence is {}, reliableAcknowledge is {}\n",
 				client->name, client->reliableSequence, client->reliableAcknowledge);
 			client->reliableAcknowledge = client->reliableSequence;

--- a/src/Components/Modules/Voice.cpp
+++ b/src/Components/Modules/Voice.cpp
@@ -168,6 +168,7 @@ namespace Components
 			voicePacket.dataSize = Game::MSG_ReadByte(msg);
 			if (voicePacket.dataSize <= 0 || voicePacket.dataSize > MAX_VOICE_PACKET_DATA)
 			{
+				Logger::PrintFail2Ban("Invalid packet from IP address: {}\n", Network::AdrToString(cl->header.netchan.remoteAddress));
 				Logger::Print(Game::CON_CHANNEL_SERVER, "Received invalid voice packet of size {} from {}\n", voicePacket.dataSize, cl->name);
 				return;
 			}


### PR DESCRIPTION
**What does this PR do?**

Allows the user to harden their servers from unwanted attacks such as RCon password brute force.
This PR adds a few prints to critical sections of the code where I think a possible attacker may attempt to send invalid data.

**How does this PR change IW4x's behaviour?**

- Adds a dvar that controls where the log file is written default: `/var/iw4x.log` (taken from fail2ban docs. For testing I used to change it to `userraw/logs/iw4x.log`. 
- Adds command line arg to set this feature one.

**Anything else we should know?**

I used these fail2ban configs and I tested them well enough confirming they work out of the box https://git.alterware.dev/AlterWare/iw4x-fail2ban

Once this PR merged I encourage the creation of a similar repo or otherwise distribute the files under this github org

Add any other context about your changes here.

**Did you check all the boxes?**

- [X ] Focus on a single fix or feature; remove any unrelated formatting or code changes
