### PR TITLE
fix(download): restore password verification

### DIFF
--- a/src/Components/Modules/Download.cpp
+++ b/src/Components/Modules/Download.cpp
@@ -478,14 +478,14 @@ namespace Components
 
 		if (len <= 0)
 		{
-			ReplyError(c, 403, "Password Required");
+			Download::ReplyError(c, 403, "Password Required");
 			return false;
 		}
 
 		const auto password = std::string(buffer, len);
 		if (password != Utils::String::DumpHex(Utils::Cryptography::SHA256::Compute(g_password), ""))
 		{
-			ReplyError(c, 403, "Invalid Password");
+			Download::ReplyError(c, 403, "Invalid Password");
 			return false;
 		}
 

--- a/src/Components/Modules/Download.cpp
+++ b/src/Components/Modules/Download.cpp
@@ -455,7 +455,7 @@ namespace Components
 
 		if (!messageOverride.empty())
 		{
-			msg = message;
+			msg = messageOverride;
 		}
 
 		mg_http_reply(connection, code, "Content-Type: text/plain\r\n", "%s", msg.c_str());
@@ -478,14 +478,14 @@ namespace Components
 
 		if (len <= 0)
 		{
-			ReplyError(connection, 403, "Password Required");
+			ReplyError(c, 403, "Password Required");
 			return false;
 		}
 
 		const auto password = std::string(buffer, len);
 		if (password != Utils::String::DumpHex(Utils::Cryptography::SHA256::Compute(g_password), ""))
 		{
-			ReplyError(connection, 403, "Invalid Password");
+			ReplyError(c, 403, "Invalid Password");
 			return false;
 		}
 

--- a/src/Components/Modules/Download.hpp
+++ b/src/Components/Modules/Download.hpp
@@ -105,7 +105,7 @@ namespace Components
 		static bool DownloadFile(ClientDownload* download, unsigned int index);
 
 		static void LogFn(char c, void* param);
-		static void ReplyError(mg_connection* connection, int code);
+		static void ReplyError(mg_connection* connection, int code, std::string messageOverride = {});
 		static void Reply(mg_connection* connection, const std::string& contentType, const std::string& data);
 
 		static std::optional<std::string> FileHandler(mg_connection* c, const mg_http_message* hm);

--- a/src/Components/Modules/Download.hpp
+++ b/src/Components/Modules/Download.hpp
@@ -17,6 +17,8 @@ namespace Components
 		static void InitiateClientDownload(const std::string& mod, bool needPassword, bool map = false);
 		static void InitiateMapDownload(const std::string& map, bool needPassword);
 
+		static void ReplyError(mg_connection* connection, int code, std::string messageOverride = {});
+
 		static Dvar::Var SV_wwwDownload;
 		static Dvar::Var SV_wwwBaseUrl;
 
@@ -105,7 +107,6 @@ namespace Components
 		static bool DownloadFile(ClientDownload* download, unsigned int index);
 
 		static void LogFn(char c, void* param);
-		static void ReplyError(mg_connection* connection, int code, std::string messageOverride = {});
 		static void Reply(mg_connection* connection, const std::string& contentType, const std::string& data);
 
 		static std::optional<std::string> FileHandler(mg_connection* c, const mg_http_message* hm);


### PR DESCRIPTION
Old feature by momo, his old code didn't work because he forgot to to call dump hex on the server password.
I removed it during the great refactoring of download.cpp when we upgraded past 4 major releases of mongoose.

Now I add it back