### PR TITLE
feat: add poolUsage(s)/assetCount commands

### DIFF
--- a/src/Game/Database.cpp
+++ b/src/Game/Database.cpp
@@ -25,6 +25,7 @@ namespace Game
 	DB_ReleaseXAssetHandler_t* DB_ReleaseXAssetHandlers = reinterpret_cast<DB_ReleaseXAssetHandler_t*>(0x799AB8);
 
 	XAssetHeader* DB_XAssetPool = reinterpret_cast<XAssetHeader*>(0x7998A8);
+	const char** g_assetNames = reinterpret_cast<const char**>(0x799278);
 	unsigned int* g_poolSize = reinterpret_cast<unsigned int*>(0x7995E8);
 
 	XBlock** g_streamBlocks = reinterpret_cast<XBlock**>(0x16E554C);

--- a/src/Game/Database.hpp
+++ b/src/Game/Database.hpp
@@ -39,7 +39,7 @@ namespace Game
 	typedef void(*DB_EnumXAssets_t)(XAssetType type, void(*)(XAssetHeader, void*), void* userdata, bool overrides);
 	extern DB_EnumXAssets_t DB_EnumXAssets;
 
-	typedef void(*DB_EnumXAssets_Internal_t)(XAssetType type, void(*)(XAssetHeader, void*), void* userdata, bool overrides);
+	typedef void(*DB_EnumXAssets_Internal_t)(XAssetType type, void(*)(XAssetHeader, void*), const void* userdata, bool overrides);
 	extern DB_EnumXAssets_Internal_t DB_EnumXAssets_Internal;
 
 	typedef XAssetHeader(*DB_FindXAssetHeader_t)(XAssetType type, const char* name);
@@ -91,6 +91,7 @@ namespace Game
 	extern DB_ReleaseXAssetHandler_t* DB_ReleaseXAssetHandlers;
 
 	extern XAssetHeader* DB_XAssetPool;
+	extern const char** g_assetNames;
 	extern unsigned int* g_poolSize;
 
 	extern XBlock** g_streamBlocks;


### PR DESCRIPTION
**What does this PR do?**

Adds 3 new commands that can be used for seeing the total number of xassets used.

- poolUsages
- poolUsage
- assetCount

**How does this PR change IW4x's behaviour?**

Existing behavior does not change.

- poolUsages
  - Lists the usage/total count of each xasset type
- poolUsage `<number>`
  - Lists the usage/total count of the specified xasset type
- assetCount
  - List the total amount of xassets used/total xasset limit

- poolUsages
![image](https://github.com/iw4x/iw4x-client/assets/13552261/03c5236b-e381-4f5f-81fb-f58027254603)

- poolUsage `<number>`
![image](https://github.com/iw4x/iw4x-client/assets/13552261/380078b5-76ea-4564-8384-e62db529c650)

- assetCount
![image](https://github.com/iw4x/iw4x-client/assets/13552261/5889bb36-c7c3-444a-80d8-5c9e90bb5c11)

**Anything else we should know?**

N/A

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Mention any [related issues](https://github.com/XLabsProject/iw4x-client/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/XLabsProject/iw4x-client/blob/master/CODESTYLE.md)
- [x] Minimize the number of commits
