### PR TITLE
fix: removed hook that can crash when loading zone

### DIFF
--- a/src/Components/Modules/Maps.cpp
+++ b/src/Components/Modules/Maps.cpp
@@ -847,11 +847,9 @@ namespace Components
 
 		// Always refresh arena when loading or unloading a zone
 		Utils::Hook::Nop(0x485017, 2);
-		Utils::Hook::Nop(0x4FD8C7, 2); // Gametypes
 		Utils::Hook::Nop(0x4BDFB7, 2); // Unknown
 		Utils::Hook::Nop(0x45ED6F, 2); // loadGameInfo
 		Utils::Hook::Nop(0x4A5888, 2); // UI_InitOnceForAllClients
-		
 
 		// Allow hiding specific smodels
 		Utils::Hook(0x50E67C, Maps::HideModelStub, HOOK_CALL).install()->quick();


### PR DESCRIPTION
**What does this PR do?**

Removing this hook fixes the crash when loading into Chinatown. 
Closes https://github.com/iw4x/iw4x-client/issues/72

**How does this PR change IW4x's behaviour?**

I did not pick up on any unwanted changes.

**Anything else we should know?**

It might be worth looking into the Chinatown to figure out what sets it apart from the rest. One thing I noted was that the loading screen for this map seems to struggle with showing the correct map name: it will start off with "Chinatown" briefly, then show "Unknown", and finally, "Chinatown" again. The console reports `Overriding asset 'MPUI_CARENTAN' of type localize`. This is the only map I noticed that would do this.
