### PR TITLE
feat: added -lan flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@
 | `-nointro`              | Skip game's cinematic intro.                   |
 | `-version`              | Print IW4x build info on startup.              |
 | `-nosteam`              | Disable friends feature and do not update Steam about the game's current status just like an invisible mode. |
+| `-lan`                  | Disable node system for the client/server and disable sending heartbeats to the master server. |
 | `-unprotect-dvars`      | Allow the server to modify saved/archive dvars. |
 | `-zonebuilder`          | Start the interactive zonebuilder tool console instead of starting the game. |
-| `-disable-notifies`     | Disable "Anti-CFG" checks |
-| `-disable-mongoose`     | Disable Mongoose HTTP server |
-| `-disable-rate-limit-check` | Disable RCon rate limit checks |
+| `-disable-notifies`     | Disable "Anti-CFG" checks. |
+| `-disable-mongoose`     | Disable Mongoose HTTP server. |
+| `-disable-rate-limit-check` | Disable RCon rate limit checks. |
 
 ## Disclaimer
 

--- a/src/Components/Modules/Dedicated.cpp
+++ b/src/Components/Modules/Dedicated.cpp
@@ -163,7 +163,7 @@ namespace Components
 	void Dedicated::Heartbeat()
 	{	
 		// Do not send a heartbeat if sv_lanOnly is set to true
-		if (SVLanOnly.get<bool>())
+		if (SVLanOnly.get<bool>() || Flags::HasFlag("lan"))
 		{
 			return;
 		}

--- a/src/Components/Modules/Node.cpp
+++ b/src/Components/Modules/Node.cpp
@@ -399,7 +399,7 @@ namespace Components
 	{
 		if (ZoneBuilder::IsEnabled()) return;
 
-		if (!Dedicated::IsEnabled() && Flags::HasFlag("lan")) return;
+		if (Flags::HasFlag("lan")) return;
 
 		if (Dedicated::IsEnabled() && Dedicated::SVLanOnly.get<bool>()) return;
 

--- a/src/Components/Modules/Node.cpp
+++ b/src/Components/Modules/Node.cpp
@@ -397,10 +397,11 @@ namespace Components
 
 	Node::Node()
 	{
-		if (ZoneBuilder::IsEnabled())
-		{
-			return;
-		}
+		if (ZoneBuilder::IsEnabled()) return;
+
+		if (!Dedicated::IsEnabled() && Flags::HasFlag("lan")) return;
+
+		if (Dedicated::IsEnabled() && Dedicated::SVLanOnly.get<bool>()) return;
 
 		net_natFix = Game::Dvar_RegisterBool("net_natFix", false, 0, "Fix node registration for certain firewalls/routers");
 


### PR DESCRIPTION
**What does this PR do?**

Adds `-lan` startup flag for offline/lan gaming. 

**How does this PR change IW4x's behaviour?**

Disables node system which would print nearly 600 error messages to the console as a result of Sys_SendPacket failing when offline (called from `Node::Entry::sendRequest`).

**Anything else we should know?**

Master server still works should the user regain internet connection.
