### PR TITLE
Replace plutools.pw with getserve.rs

### DIFF
--- a/src/Components/Modules/ServerList.cpp
+++ b/src/Components/Modules/ServerList.cpp
@@ -384,7 +384,7 @@ namespace Components
 
 			Toast::Show("cardicon_headshot", "Server Browser", "Fetching servers...", 3000);
 
-			const auto url = std::format("http://iw4x.plutools.pw/v1/servers/iw4x?protocol={}", PROTOCOL);
+			const auto url = std::format("http://iw4x.getserve.rs/v1/servers/iw4x?protocol={}", PROTOCOL);
 			const auto reply = Utils::WebIO("IW4x", url).setTimeout(5000)->get();
 			if (reply.empty())
 			{


### PR DESCRIPTION
PluTools recently renamed to getServe.rs, coming with a new domain.
While plutools.pw will be available for about another year, getserve.rs should be used.