### PR TITLE
Add BotRemoteAngles and BotAngles

### DIFF
--- a/src/Components/Modules/Bots.cpp
+++ b/src/Components/Modules/Bots.cpp
@@ -217,7 +217,7 @@ namespace Components
 			}
 
 			ZeroMemory(&g_botai[entref.entnum], sizeof(BotMovementInfo));
-			g_botai[entref.entnum].weapon = ent->client->ps.weapCommon.weapon;
+			g_botai[entref.entnum].weapon = static_cast<std::uint16_t>(ent->client->ps.weapCommon.weapon);
 			g_botai[entref.entnum].angles[0] = ent->client->ps.viewangles[0];
 			g_botai[entref.entnum].angles[1] = ent->client->ps.viewangles[1];
 			g_botai[entref.entnum].angles[2] = ent->client->ps.viewangles[2];

--- a/src/Game/Structs.hpp
+++ b/src/Game/Structs.hpp
@@ -1978,6 +1978,7 @@ namespace Game
 		CMD_BUTTON_FRAG = 1 << 14,
 		CMD_BUTTON_OFFHAND_SECONDARY = 1 << 15,
 		CMD_BUTTON_THROW = 1 << 19,
+		CMD_BUTTON_REMOTE = 1 << 20,
 	};
 
 	struct usercmd_s


### PR DESCRIPTION
**What does this PR do?**

Add `BotRemoteAngles` and `BotAngles` builtin methods for bots

Fixes `ads` `BotAction` not throwing (allows bots to shoot akimbo weapons)

Adds `remote` `BotAction`

`BotStop` assigns current weapon

Thanks for the contribution! Please provide a concise description of the problem this request solves.

**How does this PR change IW4x's behaviour?**

Are there any breaking changes? Will any existing behaviour change?
Specify the new expected behaviour if this PR adds a new gameplay feature or alters an existing game mechanic. You may provide an image or video showing the changes.

**Anything else we should know?**

Add any other context about your changes here.

**Did you check all the boxes?**

- [ ] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [ ] Mention any [related issues](https://github.com/XLabsProject/iw4x-client/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [ ] Follow our [coding conventions](https://github.com/XLabsProject/iw4x-client/blob/master/CODESTYLE.md)
- [ ] Minimize the number of commits
