### PR TITLE
stringtable: reset not found cache

### DIFF
--- a/src/Components/Modules/FileSystem.cpp
+++ b/src/Components/Modules/FileSystem.cpp
@@ -1,4 +1,5 @@
 #include <STDInclude.hpp>
+#include "StringTable.hpp"
 
 namespace Components
 {
@@ -309,6 +310,7 @@ namespace Components
 	{
 		std::lock_guard _(FSMutex);
 		Maps::GetUserMap()->freeIwd();
+		StringTable::FreeNotFoundCache();
 		Utils::Hook::Call<void(int)>(0x4A46C0)(closemfp); // FS_Shutdown
 	}
 

--- a/src/Components/Modules/StringTable.cpp
+++ b/src/Components/Modules/StringTable.cpp
@@ -59,9 +59,9 @@ namespace Components
 
 	void StringTable::FreeNotFoundCache()
 	{
-		std::erase_if(StringTableMap, [](const auto& [name, pointer])
+		std::erase_if(StringTableMap, [](const auto& table)
 		{
-			return pointer == nullptr;
+			return table.second == nullptr;
 		});
 	}
 

--- a/src/Components/Modules/StringTable.cpp
+++ b/src/Components/Modules/StringTable.cpp
@@ -57,6 +57,21 @@ namespace Components
 		return table;
 	}
 
+	void StringTable::FreeNotFoundCache()
+	{
+		for (auto i = StringTableMap.begin(); i != StringTableMap.end();)
+		{
+			if (i->second == nullptr)
+			{
+				i = StringTableMap.erase(i);
+			}
+			else
+			{
+				++i;
+			}
+		}
+	}
+
 	StringTable::StringTable()
 	{
 		AssetHandler::OnFind(Game::XAssetType::ASSET_TYPE_STRINGTABLE, [](Game::XAssetType, const std::string& _filename)

--- a/src/Components/Modules/StringTable.cpp
+++ b/src/Components/Modules/StringTable.cpp
@@ -59,17 +59,10 @@ namespace Components
 
 	void StringTable::FreeNotFoundCache()
 	{
-		for (auto i = StringTableMap.begin(); i != StringTableMap.end();)
+		std::erase_if(StringTableMap, [](const auto& [name, pointer])
 		{
-			if (i->second == nullptr)
-			{
-				i = StringTableMap.erase(i);
-			}
-			else
-			{
-				++i;
-			}
-		}
+			return pointer == nullptr;
+		});
 	}
 
 	StringTable::StringTable()

--- a/src/Components/Modules/StringTable.hpp
+++ b/src/Components/Modules/StringTable.hpp
@@ -7,6 +7,8 @@ namespace Components
 	public:
 		StringTable();
 
+		static void FreeNotFoundCache();
+
 	private:
 		static std::unordered_map<std::string, Game::StringTable*> StringTableMap;
 


### PR DESCRIPTION
This helps modders by overriding novel string tables by making sure that after fs_game is modified and a shutdown is called new tables can be looked up from raw again.