### PR TITLE
maint(map rotation): add compatibility layer for very old mods

### DIFF
--- a/src/Components/Modules/MapRotation.cpp
+++ b/src/Components/Modules/MapRotation.cpp
@@ -4,6 +4,8 @@
 #include "MapRotation.hpp"
 #include "Party.hpp"
 
+#define OLD_MAP_ROTATION_BEHAVIOUR
+
 namespace Components
 {
 	Dvar::Var MapRotation::SVRandomMapRotation;
@@ -328,6 +330,10 @@ namespace Components
 		}
 
 		ApplyRotation(rotationCurrent);
+#ifdef OLD_MAP_ROTATION_BEHAVIOUR
+		// We used to allow mods to completely control the rotation through sv_mapRotationCurrent
+		DedicatedRotation = rotationCurrent;
+#endif
 	}
 
 	void MapRotation::SetNextMap(RotationData& rotation)
@@ -371,7 +377,11 @@ namespace Components
 		{
 			Logger::Debug("Applying {}", (*Game::sv_mapRotationCurrent)->name);
 			ApplyMapRotationCurrent(mapRotationCurrent);
+#ifdef OLD_MAP_ROTATION_BEHAVIOUR
+			SetNextMap(DedicatedRotation);
+#else
 			ClearNextMap();
+ #endif
 			return;
 		}
 


### PR DESCRIPTION
**What does this PR do?**

I was requested by Xerxes who is now allegedly running this patch on a fork, to add back some code that would allow his plugin to work. This has the advantage of fixing some really old map vote mods as well.

**How does this PR change IW4x's behaviour?**

Users can change the map rotation dynamically with `sv_maprotationCurrent` Dvar and have their changes persist even after one map rotation before the Dvar was cleared after just one rotation.

**Anything else we should know?**

This does not modify or break current setups of any kind and should be a welcomed change.

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Mention any [related issues](https://github.com/XLabsProject/iw4x-client/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/XLabsProject/iw4x-client/blob/master/CODESTYLE.md)
- [X] Minimize the number of commits
