### PR TITLE
fix(map rotation): make random map dvar work again with new configs

### DIFF
--- a/src/Components/Modules/MapRotation.cpp
+++ b/src/Components/Modules/MapRotation.cpp
@@ -174,6 +174,11 @@ namespace Components
 			ParseRotation(mapRotation);
 			RandomizeMapRotation();
 		}
+		else if (!DedicatedRotation.empty())
+		{
+			// They added maps or game modes using 'addMap' or 'addGametype'
+			RandomizeMapRotation();
+		}
 	}
 
 	void MapRotation::AddMapRotationCommands()


### PR DESCRIPTION
**What does this PR do?**

With the newer configs random map dvar does not work. this fixes that

**How does this PR change IW4x's behaviour?**

Makes the rotation randomized on request by the user with the new configs

**Anything else we should know?**

No, this is a bug fix

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Mention any [related issues](https://github.com/XLabsProject/iw4x-client/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/XLabsProject/iw4x-client/blob/master/CODESTYLE.md)
- [X] Minimize the number of commits
