### PR TITLE
Fix standard attributes in middle of decl-specifiers

### DIFF
--- a/src/Game/Client.hpp
+++ b/src/Game/Client.hpp
@@ -89,12 +89,12 @@ namespace Game
 
 	extern voiceCommunication_t* cl_voiceCommunication;
 
-	extern [[nodiscard]] int CL_GetMaxXP();
-	extern [[nodiscard]] clientConnection_t* CL_GetLocalClientConnection(int localClientNum);
-	extern [[nodiscard]] connstate_t CL_GetLocalClientConnectionState(int localClientNum);
-	extern [[nodiscard]] voiceCommunication_t* CL_GetLocalClientVoiceCommunication(int localClientNum);
-	extern [[nodiscard]] clientUIActive_t* CL_GetLocalClientUIGlobals(int localClientNum);
-	extern [[nodiscard]] clientActive_t* CL_GetLocalClientGlobals(int localClientNum);
+	[[nodiscard]] extern int CL_GetMaxXP();
+	[[nodiscard]] extern clientConnection_t* CL_GetLocalClientConnection(int localClientNum);
+	[[nodiscard]] extern connstate_t CL_GetLocalClientConnectionState(int localClientNum);
+	[[nodiscard]] extern voiceCommunication_t* CL_GetLocalClientVoiceCommunication(int localClientNum);
+	[[nodiscard]] extern clientUIActive_t* CL_GetLocalClientUIGlobals(int localClientNum);
+	[[nodiscard]] extern clientActive_t* CL_GetLocalClientGlobals(int localClientNum);
 
 	extern void CL_AddDebugStar(const float* point, const float* color, int duration, int fromServer);
 

--- a/src/Game/Zone.hpp
+++ b/src/Game/Zone.hpp
@@ -22,7 +22,7 @@ namespace Game
 
 	constexpr auto PAGE_SIZE = 4096;
 
-	extern [[nodiscard]] void* Z_VirtualReserve(int size);
+	[[nodiscard]] extern void* Z_VirtualReserve(int size);
 	extern void Z_VirtualCommit(void* ptr, int size);
 	extern void Z_VirtualDecommit(void* ptr, int size);
 	extern void Z_VirtualFree(void* ptr);


### PR DESCRIPTION
Attributes can only appear first in a member declaration. MSVC is lenient here, but other compilers will generate an error accordingly.

https://eel.is/c++draft/class.mem#general

