### PR TITLE
Clip cursor to the game window.

### DIFF
--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -82,11 +82,6 @@ namespace Components
 
 		if (GetForegroundWindow() == Window::GetWindow())
 		{
-			if (r_fullscreen.get<bool>())
-			{
-				IN_ClampMouseMove();
-			}
-
 			static auto oldX = 0, oldY = 0;
 
 			auto dx = MouseRawX - oldX;
@@ -103,11 +98,14 @@ namespace Components
 			ScreenToClient(Window::GetWindow(), &curPos);
 
 			Gamepad::OnMouseMove(curPos.x, curPos.y, dx, dy);
+
 			auto recenterMouse = Game::CL_MouseEvent(curPos.x, curPos.y, dx, dy);
+
+			ClipCursor(NULL);
 
 			if (recenterMouse)
 			{
-				Game::IN_RecenterMouse();
+				RawMouse::IN_RecenterMouse();
 			}
 		}
 	}
@@ -134,6 +132,18 @@ namespace Components
 		IN_RawMouse_Init();
 	}
 
+	BOOL RawMouse::IN_RecenterMouse()
+	{
+		RECT clientRect;
+
+		GetClientRect(Window::GetWindow(), &clientRect);
+
+		ClientToScreen(Window::GetWindow(), std::bit_cast<POINT*>(&clientRect.left));
+		ClientToScreen(Window::GetWindow(), std::bit_cast<POINT*>(&clientRect.right));
+
+		return ClipCursor(&clientRect);
+	}
+
 	void RawMouse::IN_MouseMove()
 	{
 		if (M_RawInput.get<bool>())
@@ -153,6 +163,9 @@ namespace Components
 
 		Utils::Hook(0x467C03, IN_Init, HOOK_CALL).install()->quick();
 		Utils::Hook(0x64D095, IN_Init, HOOK_JUMP).install()->quick();
+
+		Utils::Hook(0x473517, IN_RecenterMouse, HOOK_CALL).install()->quick();
+		Utils::Hook(0x64C520, IN_RecenterMouse, HOOK_CALL).install()->quick();
 
 		M_RawInput = Dvar::Register<bool>("m_rawinput", true, Game::DVAR_ARCHIVE, "Use raw mouse input, Improves accuracy & has better support for higher polling rates");
 

--- a/src/Components/Modules/RawMouse.hpp
+++ b/src/Components/Modules/RawMouse.hpp
@@ -18,5 +18,6 @@ namespace Components
 		static void IN_RawMouseMove();
 		static void IN_RawMouse_Init();
 		static void IN_Init();
+		static BOOL IN_RecenterMouse();
 	};
 }


### PR DESCRIPTION
This PR addresses a bug where the cursor could move outside the game window during a flick (a very quick mouse movement to reposition the crosshair). It should also prevent the mouse cursor from "jumping" to second monitor.




