### PR TITLE
fix: Add git tags if missing

### DIFF
--- a/generate.bat
+++ b/generate.bat
@@ -1,4 +1,16 @@
 @echo off
 echo Updating submodules...
 call git submodule update --init --recursive
+
+:: Check if the repository has an upstream remote (indicating a fork)
+git remote get-url upstream >nul 2>&1
+IF ERRORLEVEL 1 (
+    echo No upstream remote found. This might be a fork.
+    echo Adding upstream...
+    git remote add upstream https://github.com/iw4x/iw4x-client.git
+    echo Adding git tags...
+    git fetch upstream --tags
+    git push origin --tags
+)
+
 call tools\premake5 %* vs2022


### PR DESCRIPTION
**What does this PR do?**

This PR adds a small fix to the `generate.bat` script.

If you fork this repository, then GitHub, by default, only copies the `develop` branch: 
![image](https://github.com/user-attachments/assets/08c5a2b0-9fd0-4f16-88e2-90e66e739f39)

The problem here is that the [premake5.lua](https://github.com/iw4x/iw4x-client/blob/34594512a10961e9b4f9b5a3ff72ba7e989c73ef/premake5.lua#L117) script requires git tags in order to generate the build information file.
Because of this, compiling a forked clone with the default settings will fail.

The easiest fix to this problem is to simply add the original repository as an upstream remote and then fetching / pushing the git tags to the fork. That's exactly what this PR does:
It first checks if there is an upstream remote, and if not, adds it and copies the git tags.

**Anything else we should know?**

It would probably be enough to just copy the most recent tag. 
However, for the sake of completeness, it will copy them all once when it generates the solution.

Another solution would be to edit the lua script, but I have no experience with Lua and, I believe, it would require the creation of a new tag, which could potentially have some caveats.