### PR TITLE
Discard non-existent dvar

### DIFF
--- a/src/Components/Modules/Dvar.cpp
+++ b/src/Components/Modules/Dvar.cpp
@@ -259,6 +259,11 @@ namespace Components
 		return Game::Dvar_RegisterFloat(dvarName, value, min, 10000.0f, flags, description);
 	}
 
+	const Game::dvar_t* Dvar::Dvar_RegisterAimLockonStrength(const char* dvarName, float value, float min, float max, std::uint16_t flags, const char* /*description*/)
+	{
+		return Game::Dvar_RegisterFloat(dvarName, value, min, max, flags, "The amount of aim assistance given by the target lock on (yaw)");
+	}
+
 	void Dvar::SetFromStringByNameSafeExternal(const char* dvarName, const char* string)
 	{
 		static std::array exceptions =
@@ -483,6 +488,9 @@ namespace Components
 
 		// Hook dvar 'perk_extendedMeleeRange' and set a higher max, better than having people force this with external programs
 		Utils::Hook(0x492D2F, Dvar_RegisterPerkExtendedMeleeRange, HOOK_CALL).install()->quick();
+
+		// Hook dvar 'aim_lockon_strength' and clarify in the description that it is for yaw, now that 'aim_lockon_pitch_strength' is registered
+		Utils::Hook(0x43FCFD, Dvar_RegisterAimLockonStrength, HOOK_CALL).install()->quick();
 
 		// un-cheat safeArea_* and add archive flags
 		Utils::Hook::Xor<std::uint32_t>(0x42E3F5, Game::DVAR_ROM | Game::DVAR_ARCHIVE); //safeArea_adjusted_horizontal

--- a/src/Components/Modules/Dvar.hpp
+++ b/src/Components/Modules/Dvar.hpp
@@ -44,6 +44,7 @@ namespace Components
 		static const Game::dvar_t* Dvar_RegisterName(const char* dvarName, const char* value, std::uint16_t flags, const char* description);
 		static const Game::dvar_t* Dvar_RegisterSVNetworkFps(const char* dvarName, int value, int min, int max, std::uint16_t flags, const char* description);
 		static const Game::dvar_t* Dvar_RegisterPerkExtendedMeleeRange(const char* dvarName, float value, float min, float max, std::uint16_t flags, const char* description);
+		static const Game::dvar_t* Dvar_RegisterAimLockonStrength(const char* dvarName, float value, float min, float max, std::uint16_t flags, const char* description);
 
 		static void SetFromStringByNameExternal(const char* dvarName, const char* string);
 		static void SetFromStringByNameSafeExternal(const char* dvarName, const char* string);

--- a/src/Components/Modules/Gamepad.cpp
+++ b/src/Components/Modules/Gamepad.cpp
@@ -495,7 +495,7 @@ namespace Components
 			return;
 		}
 
-		const auto aimAssistRange = AimAssist_Lerp(weaponDef->aimAssistRange, weaponDef->aimAssistRangeAds, aaGlob.adsLerp) * aim_aimAssistRangeScale.get<float>();
+		const auto aimAssistRange = std::lerp(weaponDef->aimAssistRange, weaponDef->aimAssistRangeAds, aaGlob.adsLerp) * aim_aimAssistRangeScale.get<float>();
 		const auto screenTarget = AimAssist_GetPrevOrBestTarget(&aaGlob, aimAssistRange, aaGlob.tweakables.lockOnRegionWidth, aaGlob.tweakables.lockOnRegionHeight, prevTargetEnt);
 
 		if (screenTarget && screenTarget->distSqr > 0.0f)
@@ -623,24 +623,19 @@ namespace Components
 		}
 
 		const auto* weaponDef = Game::BG_GetWeaponDef(static_cast<std::uint32_t>(aaGlob.ps.weapIndex));
-		const auto aimAssistRange = AimAssist_Lerp(weaponDef->aimAssistRange, weaponDef->aimAssistRangeAds, aaGlob.adsLerp) * aim_aimAssistRangeScale.get<float>();
+		const auto aimAssistRange = std::lerp(weaponDef->aimAssistRange, weaponDef->aimAssistRangeAds, aaGlob.adsLerp) * aim_aimAssistRangeScale.get<float>();
 		const auto screenTarget = AimAssist_GetBestTarget(&aaGlob, aimAssistRange, aaGlob.tweakables.slowdownRegionWidth, aaGlob.tweakables.slowdownRegionHeight);
 
 		if (screenTarget)
 		{
-			*pitchScale = AimAssist_Lerp(aim_slowdown_pitch_scale.get<float>(), aim_slowdown_pitch_scale_ads.get<float>(), aaGlob.adsLerp);
-			*yawScale = AimAssist_Lerp(aim_slowdown_yaw_scale.get<float>(), aim_slowdown_yaw_scale_ads.get<float>(), aaGlob.adsLerp);
+			*pitchScale = std::lerp(aim_slowdown_pitch_scale.get<float>(), aim_slowdown_pitch_scale_ads.get<float>(), aaGlob.adsLerp);
+			*yawScale = std::lerp(aim_slowdown_yaw_scale.get<float>(), aim_slowdown_yaw_scale_ads.get<float>(), aaGlob.adsLerp);
 		}
 
 		if (AimAssist_IsPlayerUsingOffhand(&aaGlob.ps))
 		{
 			*pitchScale = 1.0f;
 		}
-	}
-
-	float Gamepad::AimAssist_Lerp(const float from, const float to, const float fraction)
-	{
-		return (to - from) * fraction + from;
 	}
 
 	void Gamepad::AimAssist_ApplyTurnRates(const Game::AimInput* input, Game::AimOutput* output)
@@ -670,9 +665,9 @@ namespace Components
 		}
 
 		const auto sensitivity = input_viewSensitivity.get<float>();
-		auto pitchTurnRate = AimAssist_Lerp(aim_turnrate_pitch.get<float>(), aim_turnrate_pitch_ads.get<float>(), aaGlob.adsLerp);
+		auto pitchTurnRate = std::lerp(aim_turnrate_pitch.get<float>(), aim_turnrate_pitch_ads.get<float>(), aaGlob.adsLerp);
 		pitchTurnRate = slowdownPitchScale * aaGlob.fovTurnRateScale * sensitivity * pitchTurnRate;
-		auto yawTurnRate = AimAssist_Lerp(aim_turnrate_yaw.get<float>(), aim_turnrate_yaw_ads.get<float>(), aaGlob.adsLerp);
+		auto yawTurnRate = std::lerp(aim_turnrate_yaw.get<float>(), aim_turnrate_yaw_ads.get<float>(), aaGlob.adsLerp);
 		yawTurnRate = slowdownYawScale * aaGlob.fovTurnRateScale * sensitivity * yawTurnRate;
 
 		if (input->pitchMax > 0 && input->pitchMax < pitchTurnRate)

--- a/src/Components/Modules/Gamepad.cpp
+++ b/src/Components/Modules/Gamepad.cpp
@@ -218,6 +218,7 @@ namespace Components
 	Dvar::Var Gamepad::aim_slowdown_yaw_scale_ads;
 	Dvar::Var Gamepad::aim_lockon_enabled;
 	Dvar::Var Gamepad::aim_lockon_deflection;
+	Dvar::Var Gamepad::aim_lockon_pitch_strength;
 	Dvar::Var Gamepad::aim_lockon_strength;
 
 	Gamepad::GamePadGlobals::GamePadGlobals()
@@ -506,7 +507,7 @@ namespace Components
 			const auto pitchTurnRate =
 				(screenTarget->velocity[0] * aaGlob.viewAxis[2][0] + screenTarget->velocity[1] * aaGlob.viewAxis[2][1] + screenTarget->velocity[2] * aaGlob.viewAxis[2][2]
 					- (aaGlob.ps.velocity[0] * aaGlob.viewAxis[2][0] + aaGlob.ps.velocity[1] * aaGlob.viewAxis[2][1] + aaGlob.ps.velocity[2] * aaGlob.viewAxis[2][2]))
-				/ arcLength * 180.0f * aim_lockon_strength.get<float>();
+				/ arcLength * 180.0f * aim_lockon_pitch_strength.get<float>();
 
 			const auto yawTurnRate = 
 				(screenTarget->velocity[0] * aaGlob.viewAxis[1][0] + screenTarget->velocity[1] * aaGlob.viewAxis[1][1] + screenTarget->velocity[2] * aaGlob.viewAxis[1][2]
@@ -1876,6 +1877,7 @@ namespace Components
 		aim_slowdown_yaw_scale_ads = Dvar::Var("aim_slowdown_yaw_scale_ads");
 		aim_lockon_enabled = Dvar::Var("aim_lockon_enabled");
 		aim_lockon_deflection = Dvar::Var("aim_lockon_deflection");
+		aim_lockon_pitch_strength = Dvar::Register<float>("aim_lockon_pitch_strength", 0.6f, 0, 1, Game::DVAR_CHEAT, "The amount of aim assistance given by the target lock on (pitch)");
 		aim_lockon_strength = Dvar::Var("aim_lockon_strength");
 	}
 

--- a/src/Components/Modules/Gamepad.cpp
+++ b/src/Components/Modules/Gamepad.cpp
@@ -218,7 +218,6 @@ namespace Components
 	Dvar::Var Gamepad::aim_slowdown_yaw_scale_ads;
 	Dvar::Var Gamepad::aim_lockon_enabled;
 	Dvar::Var Gamepad::aim_lockon_deflection;
-	Dvar::Var Gamepad::aim_lockon_pitch_strength;
 	Dvar::Var Gamepad::aim_lockon_strength;
 
 	Gamepad::GamePadGlobals::GamePadGlobals()
@@ -507,7 +506,7 @@ namespace Components
 			const auto pitchTurnRate =
 				(screenTarget->velocity[0] * aaGlob.viewAxis[2][0] + screenTarget->velocity[1] * aaGlob.viewAxis[2][1] + screenTarget->velocity[2] * aaGlob.viewAxis[2][2]
 					- (aaGlob.ps.velocity[0] * aaGlob.viewAxis[2][0] + aaGlob.ps.velocity[1] * aaGlob.viewAxis[2][1] + aaGlob.ps.velocity[2] * aaGlob.viewAxis[2][2]))
-				/ arcLength * 180.0f * aim_lockon_pitch_strength.get<float>();
+				/ arcLength * 180.0f * aim_lockon_strength.get<float>();
 
 			const auto yawTurnRate = 
 				(screenTarget->velocity[0] * aaGlob.viewAxis[1][0] + screenTarget->velocity[1] * aaGlob.viewAxis[1][1] + screenTarget->velocity[2] * aaGlob.viewAxis[1][2]
@@ -1882,7 +1881,6 @@ namespace Components
 		aim_slowdown_yaw_scale_ads = Dvar::Var("aim_slowdown_yaw_scale_ads");
 		aim_lockon_enabled = Dvar::Var("aim_lockon_enabled");
 		aim_lockon_deflection = Dvar::Var("aim_lockon_deflection");
-		aim_lockon_pitch_strength = Dvar::Var("aim_lockon_pitch_strength");
 		aim_lockon_strength = Dvar::Var("aim_lockon_strength");
 	}
 

--- a/src/Components/Modules/Gamepad.hpp
+++ b/src/Components/Modules/Gamepad.hpp
@@ -131,7 +131,6 @@ namespace Components
 		static void AimAssist_CalcAdjustedAxis(const Game::AimInput* input, float* pitchAxis, float* yawAxis);
 		static bool AimAssist_IsSlowdownActive(const Game::AimAssistPlayerState* ps);
 		static void AimAssist_CalcSlowdown(const Game::AimInput* input, float* pitchScale, float* yawScale);
-		static float AimAssist_Lerp(float from, float to, float fraction);
 		static void AimAssist_ApplyTurnRates(const Game::AimInput* input, Game::AimOutput* output);
 		static void AimAssist_UpdateGamePadInput(const Game::AimInput* input, Game::AimOutput* output);
 

--- a/src/Components/Modules/Gamepad.hpp
+++ b/src/Components/Modules/Gamepad.hpp
@@ -111,6 +111,7 @@ namespace Components
 		static Dvar::Var aim_slowdown_yaw_scale_ads;
 		static Dvar::Var aim_lockon_enabled;
 		static Dvar::Var aim_lockon_deflection;
+		static Dvar::Var aim_lockon_pitch_strength;
 		static Dvar::Var aim_lockon_strength;
 
 		static void MSG_WriteDeltaUsercmdKeyStub();

--- a/src/Components/Modules/Gamepad.hpp
+++ b/src/Components/Modules/Gamepad.hpp
@@ -111,7 +111,6 @@ namespace Components
 		static Dvar::Var aim_slowdown_yaw_scale_ads;
 		static Dvar::Var aim_lockon_enabled;
 		static Dvar::Var aim_lockon_deflection;
-		static Dvar::Var aim_lockon_pitch_strength;
 		static Dvar::Var aim_lockon_strength;
 
 		static void MSG_WriteDeltaUsercmdKeyStub();


### PR DESCRIPTION
**What does this PR do?**

This commit removes all references to it and uses `aim_lockon_strength` as the scale/strength factor when calculating the lock-on pitch turn rate. This aligns with the behavior in the Xbox 360 version of the game.

**How does this PR change IW4x's behaviour?**

I am unsure as I do not have a controller to test.

**Anything else we should know?**

The dvar `aim_lockon_pitch_strength` exists in T5 (I believe from recollection). Whether there should be seperate dvars for lock-on pitch and yaw strength is another question, and if so, the dvars should then be registered properly.