### PR TITLE
fix dvar name in player movement

### DIFF
--- a/src/Components/Modules/PlayerMovement.cpp
+++ b/src/Components/Modules/PlayerMovement.cpp
@@ -12,7 +12,6 @@ namespace Components
 	const Game::dvar_t* PlayerMovement::BGPlayerEjection;
 	const Game::dvar_t* PlayerMovement::BGPlayerCollision;
 	const Game::dvar_t* PlayerMovement::BGClimbAnything;
-	const Game::dvar_t* PlayerMovement::BGRecoilMultiplier;
 	const Game::dvar_t* PlayerMovement::CGNoclipScaler;
 	const Game::dvar_t* PlayerMovement::CGUfoScaler;
 	const Game::dvar_t* PlayerMovement::PlayerSpectateSpeedScale;
@@ -274,33 +273,6 @@ namespace Components
 		return PlayerSpectateSpeedScale;
 	}
 
-	void PlayerMovement::BG_WeaponFireRecoil_Stub(
-		void* ps,
-		float* recoilSpeed,
-		float* kickAVel,
-		unsigned int* holdrand,
-		Game::PlayerHandIndex hand
-	)
-	{
-		float adjustedRecoilSpeed[3]{};
-		float adjustedKick[3]{};
-
-
-		Utils::Hook::Call<void(void*, float*, float*, unsigned int*, Game::PlayerHandIndex)>(0x4A5FE0)(
-			ps,
-			adjustedRecoilSpeed,
-			adjustedKick,
-			holdrand,
-			hand
-		);
-
-		for (size_t axis = 0; axis < 3; axis++)
-		{
-			recoilSpeed [axis] = adjustedRecoilSpeed[axis] * BGRecoilMultiplier->current.value;
-			kickAVel [axis] = adjustedKick[axis] * BGRecoilMultiplier->current.value;
-		}
-	}
-
 	void PlayerMovement::RegisterMovementDvars()
 	{
 		PlayerDuckedSpeedScale = Game::Dvar_RegisterFloat("player_duckedSpeedScale",
@@ -341,12 +313,7 @@ namespace Components
 
 		BGClimbAnything = Game::Dvar_RegisterBool("bg_climbAnything",
 			false, Game::DVAR_CODINFO, "Treat any surface as a ladder");
-
-		BGRecoilMultiplier = Game::Dvar_RegisterFloat("bg_recoilMultiplier",
-			1.0f, 0.0f, 1000.0f, Game::DVAR_CHEAT,
-			"The scale applied to the player recoil when firing");
 	}
-
 
 	PlayerMovement::PlayerMovement()
 	{
@@ -406,9 +373,6 @@ namespace Components
 
 		Utils::Hook(0x570020, PM_CrashLand_Stub, HOOK_CALL).install()->quick(); // Vec3Scale
 		Utils::Hook(0x4E9889, Jump_Check_Stub, HOOK_JUMP).install()->quick();
-
-		Utils::Hook(0x44D90B, BG_WeaponFireRecoil_Stub, HOOK_CALL).install()->quick();
-		Utils::Hook(0x4FB2D7, BG_WeaponFireRecoil_Stub, HOOK_CALL).install()->quick();
 
 		GSC::Script::AddMethod("IsSprinting", GScr_IsSprinting);
 

--- a/src/Components/Modules/PlayerMovement.hpp
+++ b/src/Components/Modules/PlayerMovement.hpp
@@ -17,7 +17,6 @@ namespace Components
 		static const Game::dvar_t* BGPlayerEjection;
 		static const Game::dvar_t* BGPlayerCollision;
 		static const Game::dvar_t* BGClimbAnything;
-		static const Game::dvar_t* BGRecoilMultiplier;
 		static const Game::dvar_t* CGNoclipScaler;
 		static const Game::dvar_t* CGUfoScaler;
 		static const Game::dvar_t* PlayerSpectateSpeedScale;
@@ -53,8 +52,6 @@ namespace Components
 		static void GScr_IsSprinting(Game::scr_entref_t entref);
 
 		static const Game::dvar_t* Dvar_RegisterSpectateSpeedScale(const char* dvarName, float value, float min, float max, unsigned __int16 flags, const char* description);
-
-		static void BG_WeaponFireRecoil_Stub(void* ps, float* recoilSpeed, float* kickAVel, unsigned int* holdrand, Game::PlayerHandIndex hand);
 
 		static void RegisterMovementDvars();
 	};

--- a/src/Components/Modules/Weapon.hpp
+++ b/src/Components/Modules/Weapon.hpp
@@ -17,6 +17,7 @@ namespace Components
 
 	private:
 		static const Game::dvar_t* BGWeaponOffHandFix;
+		static const Game::dvar_t* CGRecoilMultiplier;
 
 		static Game::WeaponCompleteDef* LoadWeaponCompleteDef(const char* name);
 		static void PatchLimit();
@@ -31,6 +32,8 @@ namespace Components
 		static void JavelinResetHook_Stub();
 
 		static void WeaponEntCanBeGrabbed_Stub();
+
+		static void BG_WeaponFireRecoil_Stub(void* ps, float* recoilSpeed, float* kickAVel, unsigned int* holdrand, Game::PlayerHandIndex hand);
 
 		static void PlayerCmd_InitialWeaponRaise(Game::scr_entref_t entref);
 		static void PlayerCmd_FreezeControlsAllowLook(Game::scr_entref_t entref);


### PR DESCRIPTION
Addresses parts of #61 (do not close yet)
**How does this PR change IW4x's behaviour?**

Breaking: change dvar name (necessary to avoid bad confusion as it did in the past: bg(both games) name will lead someone who is familiar with quake engine to think that dvar is checked by server side when it is NOT and must cheat protected because it is CG category (client game)

Are there any breaking changes? Will any existing behaviour change?
Yes: above there is an explanation

**Anything else we should know?**
no
Add any other context about your changes here.


