### PR TITLE
[Mods]: Clear fs_game when leaving servers

### DIFF
--- a/src/Components/Modules/Download.cpp
+++ b/src/Components/Modules/Download.cpp
@@ -5,6 +5,7 @@
 #include "Download.hpp"
 #include "Events.hpp"
 #include "MapRotation.hpp"
+#include "ModList.hpp"
 #include "Node.hpp"
 #include "Party.hpp"
 #include "ServerInfo.hpp"
@@ -348,7 +349,7 @@ namespace Components
 
 				Command::Execute("closemenu mod_download_popmenu", false);
 
-				if (Dvar::Var("cl_modVidRestart").get<bool>())
+				if (ModList::cl_modVidRestart.get<bool>())
 				{
 					Command::Execute("vid_restart", false);
 				}

--- a/src/Components/Modules/ModList.hpp
+++ b/src/Components/Modules/ModList.hpp
@@ -7,6 +7,8 @@ namespace Components
 	public:
 		ModList();
 
+		static Dvar::Var cl_modVidRestart;
+
 		static void RunMod(const std::string& mod);
 
 	private:
@@ -14,6 +16,8 @@ namespace Components
 		static unsigned int CurrentMod;
 
 		static bool HasMod(const std::string& modName);
+
+		static void ClearMods();
 
 		static unsigned int GetItemCount();
 		static const char* GetItemText(unsigned int index, int column);

--- a/src/Components/Modules/Party.cpp
+++ b/src/Components/Modules/Party.cpp
@@ -5,6 +5,7 @@
 #include "Download.hpp"
 #include "Friends.hpp"
 #include "Gamepad.hpp"
+#include "ModList.hpp"
 #include "Node.hpp"
 #include "Party.hpp"
 #include "ServerList.hpp"
@@ -530,7 +531,7 @@ namespace Components
 					{
 						Game::Dvar_SetString(*Game::fs_gameDirVar, "");
 
-						if (Dvar::Var("cl_modVidRestart").get<bool>())
+						if (ModList::cl_modVidRestart.get<bool>())
 						{
 							Command::Execute("vid_restart", false);
 						}


### PR DESCRIPTION
**What does this PR do?**

Closes #139 

**How does this PR change IW4x's behaviour?**

Unloads the mod, if loaded, when leaving a server
Fixes some bugs I spotted(unterminated Cbuf strings) in the mod list code

**Anything else we should know?**

As explained in the code #70 does not allow me to unload a mod when leaving a private match

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Mention any [related issues](https://github.com/iw4x/iw4x-client/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/iw4x/iw4x-client/blob/master/CODESTYLE.md)
- [X] Minimize the number of commits
