### PR TITLE
fix: make .str parsing with ZB useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ To use the `iw4x.dll`, you must have a valid Modern Warfare 2 installation with 
 | `-nosteam`              | Disable friends feature and do not update Steam about the game's current status just like an invisible mode. |
 | `-unprotect-dvars`      | Allow the server to modify saved/archive dvars. |
 | `-zonebuilder`          | Start the interactive zonebuilder tool console instead of starting the game. |
+| `-original-str-parsing` | (ZoneBuilder mode only) Parse .str files in the same manner as the CoD4 Mod Tools. |
 | `-disable-notifies`     | Disable "Anti-CFG" checks |
 | `-disable-mongoose`     | Disable Mongoose HTTP server |
 | `-disable-rate-limit-check` | Disable RCon rate limit checks |

--- a/src/Components/Modules/AssetInterfaces/ILocalizeEntry.cpp
+++ b/src/Components/Modules/AssetInterfaces/ILocalizeEntry.cpp
@@ -54,32 +54,34 @@ namespace Assets
 	}
 
 	void ILocalizeEntry::ParseLocalizedStringsFile(Components::ZoneBuilder::Zone* builder, const std::string& name, const std::string& filename)
-	{
-		std::vector<Game::LocalizeEntry*> assets;
-		const auto _0 = gsl::finally([]
+	{		
+		if (Components::Flags::HasFlag("-original-str-parsing"))
 		{
-			Components::Localization::ParseOutput(nullptr);
-			Components::Localization::PrefixOverride = {};
-		});
-
-		Components::Localization::PrefixOverride = Utils::String::ToUpper(name) + "_";
-		Components::Localization::ParseOutput([&assets](Game::LocalizeEntry* asset)
-		{
-			assets.push_back(asset);
-		});
+			Components::Localization::PrefixOverride = Utils::String::ToUpper(name) + "_";
+		}
 
 		const auto* psLoadedFile = Game::SE_Load(filename.data(), false);
 		if (psLoadedFile)
 		{
 			Game::Com_PrintError(Game::CON_CHANNEL_SYSTEM, "^1Localization ERROR: %s\n", psLoadedFile);
+			Components::Localization::PrefixOverride = {};
 			return;
 		}
+
+		std::vector<Game::LocalizeEntry*> assets;
+		Components::Localization::ParseOutput([&assets](Game::LocalizeEntry* asset)
+		{
+			assets.push_back(asset);
+		});
 
 		auto type = Game::DB_GetXAssetNameType("localize");
 		for (const auto& entry : assets)
 		{
 			builder->addRawAsset(type, entry);
 		}
+
+		Components::Localization::ParseOutput(nullptr);
+		Components::Localization::PrefixOverride = {};
 	}
 
 	void ILocalizeEntry::ParseLocalizedStringsJSON(Components::ZoneBuilder::Zone* builder, Components::FileSystem::File& file)


### PR DESCRIPTION
**What does this PR do?**

Makes CoD4 str parsing exclusive to a flag. Undoing this default behaviour will make ZB modder friendly and can allow Louvenarde to undo the JSON localized string parsing from the IW4x rawfiles

**How does this PR change IW4x's behaviour?**

No longer adds prefix to localized strings derived from .str file name (CoD4 mod tools behaviour)

**Anything else we should know?**

No

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Mention any [related issues](https://github.com/iw4x/iw4x-client/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/iw4x/iw4x-client/blob/master/CODESTYLE.md)
- [X] Minimize the number of commits
