### PR TITLE
Use https git url for dualsense-windows

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,4 +46,4 @@
 	url = https://github.com/iw4x/iw4-open-formats.git
 [submodule "deps/dualsense-windows"]
 	path = deps/dualsense-windows
-	url = git@github.com:Ohjurot/DualSense-Windows.git
+	url = https://github.com/Ohjurot/DualSense-Windows.git


### PR DESCRIPTION
This allows cloning on machines that don't have an ssh key set up on github.