### PR TITLE
Fix of fps drop when using a high polling rate mouse

### DIFF
--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -8,9 +8,12 @@ namespace Components
 	Dvar::Var RawMouse::M_RawInput;
 	int RawMouse::MouseRawX = 0;
 	int RawMouse::MouseRawY = 0;
+	bool RawMouse::InRawInput = false;
 
-#define K_MWHEELUP 206
-#define K_MWHEELDOWN 205
+#define K_MWHEELUP 205
+#define K_MWHEELDOWN 206
+
+#define HIGH_POLLING_FIX 1
 
 	void RawMouse::IN_ClampMouseMove()
 	{
@@ -61,97 +64,162 @@ namespace Components
 		GetRawInputData((HRAWINPUT)lParam, RID_INPUT, lpb, &dwSize, sizeof(RAWINPUTHEADER));
 
 		auto* raw = reinterpret_cast<RAWINPUT*>(lpb);
-		if (raw->header.dwType == RIM_TYPEMOUSE)
+		if (raw->header.dwType != RIM_TYPEMOUSE)
+			return TRUE;
+		// Is there's really absolute mouse on earth?
+		if (raw->data.mouse.usFlags & MOUSE_MOVE_ABSOLUTE)
 		{
-			// Is there's really absolute mouse on earth?
-			if (raw->data.mouse.usFlags & MOUSE_MOVE_ABSOLUTE)
-			{
-				MouseRawX = raw->data.mouse.lLastX;
-				MouseRawY = raw->data.mouse.lLastY;
-			}
-			else
-			{
-				MouseRawX += raw->data.mouse.lLastX;
-				MouseRawY += raw->data.mouse.lLastY;
-			}
-
-			// we need to repeat this check there, since raw input sends attack if game is alt tabbed.
-			if (GetForegroundWindow() == Window::GetWindow())
-			{
-				auto mouse_event_flag = (raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_1_DOWN) != 0;
-				if ((raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_2_DOWN) != 0)
-					mouse_event_flag |= 2u;
-				if ((raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_3_DOWN) != 0)
-					mouse_event_flag |= 4u;
-				if ((raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_4_DOWN) != 0)
-					mouse_event_flag |= 8u;
-				if ((raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_5_DOWN) != 0)
-					mouse_event_flag |= 0x10u;
-
-				Game::IN_MouseEvent(mouse_event_flag);
-
-				if (raw->data.mouse.usButtonFlags & RI_MOUSE_WHEEL)
-				{
-					const SHORT scroll_delta = static_cast<SHORT>(raw->data.mouse.usButtonData);
-
-					if (scroll_delta > 0)
-						Game::Sys_QueEvents(Game::sysMsgTime(), 1, K_MWHEELDOWN, 0, 0);
-					if (scroll_delta < 0)
-						Game::Sys_QueEvents(Game::sysMsgTime(), 1, K_MWHEELUP, 0, 0);
-				}
-			}
+			MouseRawX = raw->data.mouse.lLastX;
+			MouseRawY = raw->data.mouse.lLastY;
+		}
+		else
+		{
+			MouseRawX += raw->data.mouse.lLastX;
+			MouseRawY += raw->data.mouse.lLastY;
 		}
 
+#if HIGH_POLLING_FIX
+		// we need to repeat this check there, since raw input sends attack if game is alt tabbed.
+		if (GetForegroundWindow() != Window::GetWindow())
+			return TRUE;
+
+		int mouse_event_flag = (raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_1_DOWN) != 0;
+		if ((raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_2_DOWN) != 0)
+			mouse_event_flag |= 2u;
+		if ((raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_3_DOWN) != 0)
+			mouse_event_flag |= 4u;
+		if ((raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_4_DOWN) != 0)
+			mouse_event_flag |= 8u;
+		if ((raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_5_DOWN) != 0)
+			mouse_event_flag |= 0x10u;
+
+		Game::IN_MouseEvent(mouse_event_flag);
+
+		if (raw->data.mouse.usButtonFlags & RI_MOUSE_WHEEL)
+		{
+			const SHORT scroll_delta = static_cast<SHORT>(raw->data.mouse.usButtonData);
+
+			if (scroll_delta > 0)
+				Game::Sys_QueEvents(Game::sysMsgTime(), 1, K_MWHEELDOWN, 0, 0);
+			if (scroll_delta < 0)
+				Game::Sys_QueEvents(Game::sysMsgTime(), 1, K_MWHEELUP, 0, 0);
+		}
+#endif
+
 		return TRUE;
+	}
+
+	bool RawMouse::IsMouseInClientBounds()
+	{
+		POINT curPos;
+		GetCursorPos(&curPos);
+		ScreenToClient(Window::GetWindow(), &curPos);
+
+		RECT rect;
+		Window::Dimension(Window::GetWindow(), &rect);
+
+		return (curPos.y >= 0 && curPos.x >= 0 && (rect.right - rect.left) >= curPos.x && (rect.bottom - rect.top) >= curPos.y);
+	}
+
+	BOOL RawMouse::OnKillFocus(LPARAM lParam, WPARAM)
+	{
+		static auto r_autopriority = Dvar::Var("r_autopriority");
+		ToggleRawInput(false);
+		if (r_autopriority.get<bool>())
+			SetPriorityClass(GetCurrentProcess(), IDLE_PRIORITY_CLASS);
+		SetFocus(nullptr);
+		return FALSE;
+	}
+
+	BOOL RawMouse::OnSetFocus(LPARAM lParam, WPARAM)
+	{
+		static auto r_autopriority = Dvar::Var("r_autopriority");
+		ToggleRawInput(IsMouseInClientBounds());
+		if (r_autopriority.get<bool>())
+			SetPriorityClass(GetCurrentProcess(), NORMAL_PRIORITY_CLASS);
+
+		SetFocus(Window::GetWindow());
+		return FALSE;
 	}
 
 	void RawMouse::IN_RawMouseMove()
 	{
 		static auto r_fullscreen = Dvar::Var("r_fullscreen");
 
-		if (GetForegroundWindow() == Window::GetWindow())
+		if (GetForegroundWindow() != Window::GetWindow())
+			return;
+
+		static auto oldX = 0, oldY = 0;
+
+		auto dx = MouseRawX - oldX;
+		auto dy = MouseRawY - oldY;
+
+		oldX = MouseRawX;
+		oldY = MouseRawY;
+
+		// Don't use raw input for menu?
+		// Because it needs to call the ScreenToClient
+		tagPOINT curPos;
+		GetCursorPos(&curPos);
+		Game::s_wmv->oldPos = curPos;
+		ScreenToClient(Window::GetWindow(), &curPos);
+
+		Gamepad::OnMouseMove(curPos.x, curPos.y, dx, dy);
+
+		auto recenterMouse = Game::CL_MouseEvent(curPos.x, curPos.y, dx, dy);
+
+		ClipCursor(NULL);
+
+		if (recenterMouse)
 		{
-			static auto oldX = 0, oldY = 0;
-
-			auto dx = MouseRawX - oldX;
-			auto dy = MouseRawY - oldY;
-
-			oldX = MouseRawX;
-			oldY = MouseRawY;
-
-			// Don't use raw input for menu?
-			// Because it needs to call the ScreenToClient
-			tagPOINT curPos;
-			GetCursorPos(&curPos);
-			Game::s_wmv->oldPos = curPos;
-			ScreenToClient(Window::GetWindow(), &curPos);
-
-			Gamepad::OnMouseMove(curPos.x, curPos.y, dx, dy);
-
-			auto recenterMouse = Game::CL_MouseEvent(curPos.x, curPos.y, dx, dy);
-
-			ClipCursor(NULL);
-
-			if (recenterMouse)
-			{
-				RawMouse::IN_RecenterMouse();
-			}
+			RawMouse::IN_RecenterMouse();
 		}
 	}
 
+	bool RawMouse::ToggleRawInput(bool enable)
+	{
+		if (!M_RawInput.get<bool>())
+		{
+			if (!InRawInput)
+				return false;
+
+			enable = false;
+		}
+		else
+		{
+			if (InRawInput == enable)
+				return InRawInput;
+		}
+
+#if HIGH_POLLING_FIX
+		constexpr DWORD rawinput_flags = RIDEV_INPUTSINK | RIDEV_NOLEGACY | RIDEV_CAPTUREMOUSE;
+#else
+		constexpr DWORD rawinput_flags = RIDEV_INPUTSINK;
+#endif
+
+		RAWINPUTDEVICE Rid[1];
+		Rid[0].usUsagePage = 0x01; // HID_USAGE_PAGE_GENERIC
+		Rid[0].usUsage = 0x02; // HID_USAGE_GENERIC_MOUSE
+		Rid[0].dwFlags = (enable ? rawinput_flags : RIDEV_REMOVE);
+		Rid[0].hwndTarget = enable ? Window::GetWindow() : NULL;
+
+		bool success = RegisterRawInputDevices(Rid, ARRAYSIZE(Rid), sizeof(Rid[0])) == TRUE;
+
+		InRawInput = success && (Rid[0].dwFlags & RIDEV_REMOVE) == 0;
+#ifdef _DEBUG
+		if (InRawInput)
+			Logger::Debug("Raw Mouse enabled");
+		else
+			Logger::Debug("Raw Mouse disabled");
+#endif
+		return true;
+}
+
 	void RawMouse::IN_RawMouse_Init()
 	{
-		if (Window::GetWindow() && M_RawInput.get<bool>())
-		{
+		if (Window::GetWindow() && ToggleRawInput(true)) {
 			Logger::Debug("Raw Mouse Init");
-
-			RAWINPUTDEVICE Rid[1];
-			Rid[0].usUsagePage = 0x01; // HID_USAGE_PAGE_GENERIC
-			Rid[0].usUsage = 0x02; // HID_USAGE_GENERIC_MOUSE
-			Rid[0].dwFlags = RIDEV_INPUTSINK | RIDEV_NOLEGACY | RIDEV_CAPTUREMOUSE;
-			Rid[0].hwndTarget = Window::GetWindow();
-
-			RegisterRawInputDevices(Rid, ARRAYSIZE(Rid), sizeof(Rid[0]));
+			InRawInput = true;
 		}
 	}
 
@@ -159,6 +227,15 @@ namespace Components
 	{
 		Game::IN_Init();
 		IN_RawMouse_Init();
+	}
+
+	void RawMouse::IN_Frame()
+	{
+		bool focused = GetForegroundWindow() == Window::GetWindow();
+		if (focused)
+			focused = IsMouseInClientBounds();
+		ToggleRawInput(focused);
+		return Game::IN_Frame();
 	}
 
 	BOOL RawMouse::IN_RecenterMouse()
@@ -175,7 +252,7 @@ namespace Components
 
 	void RawMouse::IN_MouseMove()
 	{
-		if (M_RawInput.get<bool>())
+		if (InRawInput)
 		{
 			IN_RawMouseMove();
 		}
@@ -193,12 +270,17 @@ namespace Components
 		Utils::Hook(0x467C03, IN_Init, HOOK_CALL).install()->quick();
 		Utils::Hook(0x64D095, IN_Init, HOOK_JUMP).install()->quick();
 
-		Utils::Hook(0x473517, IN_RecenterMouse, HOOK_CALL).install()->quick();
+		Utils::Hook(0x60BFB9, IN_Frame, HOOK_CALL).install()->quick();
+		Utils::Hook(0x4A87E2, IN_Frame, HOOK_CALL).install()->quick();
+		Utils::Hook(0x48A0E6, IN_Frame, HOOK_CALL).install()->quick();
+
 		Utils::Hook(0x64C520, IN_RecenterMouse, HOOK_CALL).install()->quick();
 
 		M_RawInput = Dvar::Register<bool>("m_rawinput", true, Game::DVAR_ARCHIVE, "Use raw mouse input, Improves accuracy & has better support for higher polling rates");
 
 		Window::OnWndMessage(WM_INPUT, OnRawInput);
+		Window::OnWndMessage(WM_KILLFOCUS, OnKillFocus);
+		Window::OnWndMessage(WM_SETFOCUS, OnSetFocus);
 		Window::OnCreate(IN_RawMouse_Init);
 	}
 }

--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -71,6 +71,22 @@ namespace Components
 				MouseRawX += raw->data.mouse.lLastX;
 				MouseRawY += raw->data.mouse.lLastY;
 			}
+
+			// we need to repeat this check there, since raw input sends attack if game is alt tabbed.
+			if (GetForegroundWindow() == Window::GetWindow())
+			{
+				auto mouse_event_flag = (raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_1_DOWN) != 0;
+				if ((raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_2_DOWN) != 0)
+					mouse_event_flag |= 2u;
+				if ((raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_3_DOWN) != 0)
+					mouse_event_flag |= 4u;
+				if ((raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_4_DOWN) != 0)
+					mouse_event_flag |= 8u;
+				if ((raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_5_DOWN) != 0)
+					mouse_event_flag |= 0x10u;
+
+				Game::IN_MouseEvent(mouse_event_flag);
+			}
 		}
 
 		return TRUE;

--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -10,6 +10,7 @@ namespace Components
 	int RawMouse::MouseRawY = 0;
 	bool RawMouse::InRawInput = false;
 	bool RawMouse::RawInputWasEverEnabled = false;
+	bool RawMouse::RawInputSupported = false;
 
 	constexpr const int K_MWHEELUP = 205;
 	constexpr const int K_MWHEELDOWN = 206;
@@ -192,9 +193,9 @@ namespace Components
 
 	bool RawMouse::ToggleRawInput(bool enable)
 	{
-		if (!M_RawInput.get<bool>())
+		if (!RawInputSupported || !M_RawInput.get<bool>())
 		{
-			if (!InRawInput || !RawInputWasEverEnabled)
+			if (!InRawInput)
 				return false;
 
 			enable = false;
@@ -234,6 +235,18 @@ namespace Components
 
 	void RawMouse::IN_RawMouse_Init()
 	{
+		RawInputSupported = false;
+
+		HMODULE user32 = GetModuleHandleA("USER32.dll");
+		if (user32)
+		{
+			PVOID pfnRegisterRawInputDevices = GetProcAddress(user32, "RegisterRawInputDevices");
+			PVOID pfnGetRawInputData = GetProcAddress(user32, "GetRawInputData");
+		
+			if (pfnRegisterRawInputDevices && pfnGetRawInputData)
+				RawInputSupported = true;
+		}
+
 		if (Window::GetWindow() && ToggleRawInput(true)) {
 			Logger::Debug("Raw Mouse Init");
 		}

--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -9,6 +9,9 @@ namespace Components
 	int RawMouse::MouseRawX = 0;
 	int RawMouse::MouseRawY = 0;
 
+#define K_MWHEELUP 206
+#define K_MWHEELDOWN 205
+
 	void RawMouse::IN_ClampMouseMove()
 	{
 		tagRECT rc;
@@ -86,6 +89,16 @@ namespace Components
 					mouse_event_flag |= 0x10u;
 
 				Game::IN_MouseEvent(mouse_event_flag);
+
+				if (raw->data.mouse.usButtonFlags & RI_MOUSE_WHEEL)
+				{
+					const SHORT scroll_delta = static_cast<SHORT>(raw->data.mouse.usButtonData);
+
+					if (scroll_delta > 0)
+						Game::Sys_QueEvents(Game::sysMsgTime(), 1, K_MWHEELDOWN, 0, 0);
+					if (scroll_delta < 0)
+						Game::Sys_QueEvents(Game::sysMsgTime(), 1, K_MWHEELUP, 0, 0);
+				}
 			}
 		}
 
@@ -135,7 +148,7 @@ namespace Components
 			RAWINPUTDEVICE Rid[1];
 			Rid[0].usUsagePage = 0x01; // HID_USAGE_PAGE_GENERIC
 			Rid[0].usUsage = 0x02; // HID_USAGE_GENERIC_MOUSE
-			Rid[0].dwFlags = RIDEV_INPUTSINK;
+			Rid[0].dwFlags = RIDEV_INPUTSINK | RIDEV_NOLEGACY | RIDEV_CAPTUREMOUSE;
 			Rid[0].hwndTarget = Window::GetWindow();
 
 			RegisterRawInputDevices(Rid, ARRAYSIZE(Rid), sizeof(Rid[0]));

--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -10,12 +10,20 @@ namespace Components
 {
 	void raw_mouse_value_t::ResetDelta()
 	{
-		previous = current;
+		this->previous = this->current;
 	}
 
 	int raw_mouse_value_t::GetDelta() const
 	{
-		return current - previous;
+		return this->current - this->previous;
+	}
+
+	void raw_mouse_value_t::Update(int value, bool absolute)
+	{
+		if (absolute) // if mouse is absolute, reset current value
+			this->current = 0;
+
+		this->current += value;
 	}
 
 	Dvar::Var RawMouse::M_RawInput;
@@ -160,16 +168,10 @@ namespace Components
 			return TRUE;
 
 		// Is there's really absolute mouse on earth?
-		if (raw.data.mouse.usFlags & MOUSE_MOVE_ABSOLUTE)
-		{
-			MouseRawX.current = raw.data.mouse.lLastX;
-			MouseRawY.current = raw.data.mouse.lLastY;
-		}
-		else
-		{
-			MouseRawX.current += raw.data.mouse.lLastX;
-			MouseRawY.current += raw.data.mouse.lLastY;
-		}
+		const bool absolute_mouse_move = (raw.data.mouse.usFlags & MOUSE_MOVE_ABSOLUTE) != 0u;
+
+		MouseRawX.Update(raw.data.mouse.lLastX, absolute_mouse_move);
+		MouseRawY.Update(raw.data.mouse.lLastY, absolute_mouse_move);
 
 		// fix of angle snap when alt tabbing.
 		if (FirstRawInputUpdate)

--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -274,6 +274,7 @@ namespace Components
 		Utils::Hook(0x4A87E2, IN_Frame, HOOK_CALL).install()->quick();
 		Utils::Hook(0x48A0E6, IN_Frame, HOOK_CALL).install()->quick();
 
+		Utils::Hook(0x473517, IN_RecenterMouse, HOOK_CALL).install()->quick();
 		Utils::Hook(0x64C520, IN_RecenterMouse, HOOK_CALL).install()->quick();
 
 		M_RawInput = Dvar::Register<bool>("m_rawinput", true, Game::DVAR_ARCHIVE, "Use raw mouse input, Improves accuracy & has better support for higher polling rates");

--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -220,6 +220,9 @@ namespace Components
 
 		bool success = RegisterRawInputDevices(Rid, ARRAYSIZE(Rid), sizeof(Rid[0])) == TRUE;
 
+		if (!success)
+			Logger::Warning(Game::CON_CHANNEL_SYSTEM, "RawInputDevices: failed: {}\n", GetLastError());
+
 		if (success && enable) //
 			RawInputWasEverEnabled = true;
 

--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -14,7 +14,6 @@ namespace Components
 	int RawMouse::MouseRawEvents = 0;
 
 	bool RawMouse::InRawInput = false;
-	bool RawMouse::RawInputSupported = false;
 
 	constexpr const int K_MWHEELUP = 205;
 	constexpr const int K_MWHEELDOWN = 206;
@@ -208,7 +207,7 @@ namespace Components
 
 	bool RawMouse::ToggleRawInput(bool enable)
 	{
-		if (!RawInputSupported || !M_RawInput.get<bool>())
+		if (!M_RawInput.get<bool>())
 		{
 			if (!InRawInput)
 				return false;
@@ -254,18 +253,6 @@ namespace Components
 
 	void RawMouse::IN_RawMouse_Init()
 	{
-		RawInputSupported = false;
-
-		HMODULE user32 = GetModuleHandleA("USER32.dll");
-		if (user32)
-		{
-			PVOID pfnRegisterRawInputDevices = GetProcAddress(user32, "RegisterRawInputDevices");
-			PVOID pfnGetRawInputData = GetProcAddress(user32, "GetRawInputData");
-
-			if (pfnRegisterRawInputDevices && pfnGetRawInputData)
-				RawInputSupported = true;
-		}
-
 		if (Window::GetWindow() && ToggleRawInput(true)) {
 			Logger::Debug("Raw Mouse Init");
 		}

--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -297,12 +297,14 @@ namespace Components
 		{
 			InRawInput = (Rid[0].dwFlags & RIDEV_REMOVE) == 0u;
 
-#ifdef _DEBUG
-			if (InRawInput)
-				Logger::Debug("Raw Mouse enabled");
-			else
-				Logger::Debug("Raw Mouse disabled");
-#endif
+
+			if (M_RawInputVerbose.get<bool>())
+			{
+				if (InRawInput)
+					Logger::Debug("Raw Input enabled");
+				else
+					Logger::Debug("Raw Input disabled");
+			}
 
 			if (!InRawInput)
 				ResetMouseRawEvents();

--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -11,8 +11,8 @@ namespace Components
 	bool RawMouse::InRawInput = false;
 	bool RawMouse::RawInputWasEverEnabled = false;
 
-#define K_MWHEELUP 205
-#define K_MWHEELDOWN 206
+	constexpr const int K_MWHEELUP = 205;
+	constexpr const int K_MWHEELDOWN = 206;
 
 #define HIGH_POLLING_FIX 1
 
@@ -62,6 +62,13 @@ namespace Components
 		ClampMousePos(curPos);
 	}
 
+	bool CheckButtonFlag(DWORD usButtonFlags, DWORD flag_down)
+	{
+		DWORD flag_up = (flag_down << 1);
+		DWORD flag = (flag_down | flag_up);
+		return (usButtonFlags & flag) != 0u;
+	}
+
 	BOOL RawMouse::OnRawInput(LPARAM lParam, WPARAM)
 	{
 		if (!M_RawInput.get<bool>())
@@ -92,14 +99,14 @@ namespace Components
 		if (GetForegroundWindow() != Window::GetWindow())
 			return TRUE;
 
-		int mouse_event_flag = (raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_1_DOWN) != 0;
-		if ((raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_2_DOWN) != 0)
+		int mouse_event_flag = CheckButtonFlag(raw->data.mouse.usButtonFlags, RI_MOUSE_BUTTON_1_DOWN);
+		if (CheckButtonFlag(raw->data.mouse.usButtonFlags, RI_MOUSE_BUTTON_2_DOWN))
 			mouse_event_flag |= 2u;
-		if ((raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_3_DOWN) != 0)
+		if (CheckButtonFlag(raw->data.mouse.usButtonFlags, RI_MOUSE_BUTTON_3_DOWN))
 			mouse_event_flag |= 4u;
-		if ((raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_4_DOWN) != 0)
+		if (CheckButtonFlag(raw->data.mouse.usButtonFlags, RI_MOUSE_BUTTON_4_DOWN))
 			mouse_event_flag |= 8u;
-		if ((raw->data.mouse.usButtonFlags & RI_MOUSE_BUTTON_5_DOWN) != 0)
+		if (CheckButtonFlag(raw->data.mouse.usButtonFlags, RI_MOUSE_BUTTON_5_DOWN))
 			mouse_event_flag |= 0x10u;
 
 		Game::IN_MouseEvent(mouse_event_flag);

--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -150,7 +150,7 @@ namespace Components
 		return (curPos.y >= 0 && curPos.x >= 0 && (rect.right - rect.left) >= curPos.x && (rect.bottom - rect.top) >= curPos.y);
 	}
 
-	BOOL RawMouse::OnKillFocus(LPARAM lParam, WPARAM)
+	BOOL RawMouse::OnKillFocus([[maybe_unused]] LPARAM lParam, WPARAM)
 	{
 		static auto r_autopriority = Dvar::Var("r_autopriority");
 		ToggleRawInput(false);
@@ -161,7 +161,7 @@ namespace Components
 		return FALSE;
 	}
 
-	BOOL RawMouse::OnSetFocus(LPARAM lParam, WPARAM)
+	BOOL RawMouse::OnSetFocus([[maybe_unused]] LPARAM lParam, WPARAM)
 	{
 		static auto r_autopriority = Dvar::Var("r_autopriority");
 		ToggleRawInput(IsMouseInClientBounds());

--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -243,7 +243,7 @@ namespace Components
 
 		Game::IN_MouseEvent(MouseEvents);
 
-		// we should call DefWindowProcA there as game, but msg is not available in arguments...
+		// we should call DefWindowProcA there as game, thats why there is 8 1line functions...
 		return DefWindowProcA(Window::GetWindow(), Msg, wParam, lParam);
 	}
 

--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -104,28 +104,28 @@ namespace Components
 		FirstRawInputUpdate = true;
 	}
 
-	void RawMouse::ProcessMouseRawEvent(DWORD usButtonFlags, DWORD flag_down, DWORD mouse_event)
+	void RawMouse::ProcessMouseRawEvent(DWORD usButtonFlags, DWORD flagDown, DWORD mouseEvent)
 	{
-		const uint32_t pre_events = MouseRawEvents;
+		const uint32_t prevMouseEvents = MouseRawEvents;
 
-		if (CheckButtonFlag(usButtonFlags, flag_down))
+		if (CheckButtonFlag(usButtonFlags, flagDown))
 		{
 			if (M_RawInputVerbose.get<bool>())
 			{
-				if ((pre_events & mouse_event) != 0u)
+				if ((prevMouseEvents & mouseEvent) != 0u)
 					Logger::Debug("!! Pressing button that wasn't released");
 
-				Logger::Debug("Mouse button down: [{}, {}]", mouse_event, pre_events);
+				Logger::Debug("Mouse button down: [{}, {}]", mouseEvent, prevMouseEvents);
 			}
 
-			MouseRawEvents |= mouse_event;
+			MouseRawEvents |= mouseEvent;
 		}
 
-		if (CheckButtonFlag(usButtonFlags, flag_down << 1u))
+		if (CheckButtonFlag(usButtonFlags, flagDown << 1u))
 		{
-			// Sometimes when alt-tabbing this thing somehow gets passed there,
+			// Sometimes when alt-tabbing LMB release somehow gets passed there,
 			// releasing button that was not even pressed...
-			if ((pre_events & mouse_event) == 0u)
+			if ((prevMouseEvents & mouseEvent) == 0u)
 			{
 				if (M_RawInputVerbose.get<bool>())
 					Logger::Debug("!! Releasing button that wasn't pressed");
@@ -134,9 +134,9 @@ namespace Components
 			}
 
 			if (M_RawInputVerbose.get<bool>())
-				Logger::Debug("Mouse button up: [{}, {}]", mouse_event, pre_events);
+				Logger::Debug("Mouse button up: [{}, {}]", mouseEvent, prevMouseEvents);
 
-			MouseRawEvents &= ~mouse_event;
+			MouseRawEvents &= ~mouseEvent;
 		}
 	}
 
@@ -167,10 +167,10 @@ namespace Components
 			return TRUE;
 
 		// Is there's really absolute mouse on earth?
-		const bool absolute_mouse_move = (raw.data.mouse.usFlags & MOUSE_MOVE_ABSOLUTE) != 0u;
+		const bool bAbsMouseMove = (raw.data.mouse.usFlags & MOUSE_MOVE_ABSOLUTE) != 0u;
 
-		MouseRawX.Update(raw.data.mouse.lLastX, absolute_mouse_move);
-		MouseRawY.Update(raw.data.mouse.lLastY, absolute_mouse_move);
+		MouseRawX.Update(raw.data.mouse.lLastX, bAbsMouseMove);
+		MouseRawY.Update(raw.data.mouse.lLastY, bAbsMouseMove);
 
 		// fix of angle snap when alt tabbing.
 		if (FirstRawInputUpdate)
@@ -281,12 +281,12 @@ namespace Components
 				return InRawInput;
 		}
 
-		constexpr DWORD rawinput_flags = RIDEV_INPUTSINK | RIDEV_NOLEGACY;
+		constexpr DWORD rawMouseFlags = RIDEV_INPUTSINK | RIDEV_NOLEGACY;
 
 		RAWINPUTDEVICE Rid[1];
 		Rid[0].usUsagePage = HID_USAGE_PAGE_GENERIC;
 		Rid[0].usUsage = HID_USAGE_GENERIC_MOUSE;
-		Rid[0].dwFlags = (enable ? rawinput_flags : RIDEV_REMOVE);
+		Rid[0].dwFlags = (enable ? rawMouseFlags : RIDEV_REMOVE);
 		Rid[0].hwndTarget = enable ? Window::GetWindow() : NULL;
 
 		bool success = RegisterRawInputDevices(Rid, ARRAYSIZE(Rid), sizeof(Rid[0])) == TRUE;
@@ -296,7 +296,6 @@ namespace Components
 		else
 		{
 			InRawInput = (Rid[0].dwFlags & RIDEV_REMOVE) == 0u;
-
 
 			if (M_RawInputVerbose.get<bool>())
 			{

--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -84,8 +84,10 @@ namespace Components
 
 	BOOL RawMouse::OnRawInput(LPARAM lParam, WPARAM)
 	{
-		if (!M_RawInput.get<bool>())
+		if (!M_RawInput.get<bool>()) {
+			ResetMouseRawEvents();
 			return TRUE;
+		}
 
 		auto dwSize = sizeof(RAWINPUT);
 		static BYTE lpb[sizeof(RAWINPUT)];
@@ -109,8 +111,10 @@ namespace Components
 
 #if HIGH_POLLING_FIX
 		// we need to repeat this check there, since raw input sends attack if game is alt tabbed.
-		if (GetForegroundWindow() != Window::GetWindow())
+		if (GetForegroundWindow() != Window::GetWindow()) {
+			ResetMouseRawEvents();
 			return TRUE;
+		}
 
 		ProcessMouseRawEvent(raw->data.mouse.usButtonFlags, RI_MOUSE_BUTTON_1_DOWN, 1);
 		ProcessMouseRawEvent(raw->data.mouse.usButtonFlags, RI_MOUSE_BUTTON_2_DOWN, 2);

--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -332,7 +332,7 @@ namespace Components
 		ResetMouseRawEvents();
 
 		R_AutoPriority = Dvar::Var("r_autopriority");
-		R_FullScreen = Dvar::Var("r_fullscreen");
+		R_FullScreen = Dvar::Var(0x069F0DA0);
 	}
 
 	void RawMouse::IN_Frame()

--- a/src/Components/Modules/RawMouse.hpp
+++ b/src/Components/Modules/RawMouse.hpp
@@ -12,12 +12,18 @@ namespace Components
 	private:
 		static Dvar::Var M_RawInput;
 		static int MouseRawX, MouseRawY;
+		static bool InRawInput;
 
 		static void IN_ClampMouseMove();
 		static BOOL OnRawInput(LPARAM lParam, WPARAM);
+		static bool IsMouseInClientBounds();
+		static BOOL OnKillFocus(LPARAM lParam, WPARAM);
+		static BOOL OnSetFocus(LPARAM lParam, WPARAM);
 		static void IN_RawMouseMove();
+		static bool ToggleRawInput(bool enable = true);
 		static void IN_RawMouse_Init();
 		static void IN_Init();
+		static void IN_Frame();
 		static BOOL IN_RecenterMouse();
 	};
 }

--- a/src/Components/Modules/RawMouse.hpp
+++ b/src/Components/Modules/RawMouse.hpp
@@ -11,10 +11,12 @@ namespace Components
 
 	private:
 		static Dvar::Var M_RawInput;
-		static int MouseRawX, MouseRawY;
+		static int MouseRawX, MouseRawY, MouseRawEvents;
 		static bool InRawInput, RawInputWasEverEnabled, RawInputSupported;
 
 		static void IN_ClampMouseMove();
+		static void ResetMouseRawEvents();
+		static void ProcessMouseRawEvent(DWORD usButtonFlags, DWORD flag_down, DWORD mouse_event);
 		static BOOL OnRawInput(LPARAM lParam, WPARAM);
 		static bool IsMouseInClientBounds();
 		static BOOL OnKillFocus(LPARAM lParam, WPARAM);

--- a/src/Components/Modules/RawMouse.hpp
+++ b/src/Components/Modules/RawMouse.hpp
@@ -9,6 +9,7 @@ namespace Components
 
 		void ResetDelta();
 		int GetDelta() const;
+		void Update(int value, bool absolute);
 	};
 
 	class RawMouse : public Component

--- a/src/Components/Modules/RawMouse.hpp
+++ b/src/Components/Modules/RawMouse.hpp
@@ -12,7 +12,7 @@ namespace Components
 	private:
 		static Dvar::Var M_RawInput;
 		static int MouseRawX, MouseRawY;
-		static bool InRawInput;
+		static bool InRawInput, RawInputWasEverEnabled;
 
 		static void IN_ClampMouseMove();
 		static BOOL OnRawInput(LPARAM lParam, WPARAM);

--- a/src/Components/Modules/RawMouse.hpp
+++ b/src/Components/Modules/RawMouse.hpp
@@ -2,7 +2,7 @@
 
 namespace Components
 {
-	struct raw_mouse_value_t
+	struct rawMouseValue_t
 	{
 		int current = 0;
 		int previous = 0;
@@ -20,8 +20,8 @@ namespace Components
 		static void IN_MouseMove();
 
 	private:
-		static Dvar::Var M_RawInput, R_FullScreen, R_AutoPriority;
-		static raw_mouse_value_t MouseRawX, MouseRawY;
+		static Dvar::Var M_RawInput, M_RawInputVerbose, R_FullScreen, R_AutoPriority;
+		static rawMouseValue_t MouseRawX, MouseRawY;
 		static uint32_t MouseRawEvents;
 		static bool InRawInput, FirstRawInputUpdate;
 

--- a/src/Components/Modules/RawMouse.hpp
+++ b/src/Components/Modules/RawMouse.hpp
@@ -19,6 +19,20 @@ namespace Components
 
 		static void IN_MouseMove();
 
+		static BOOL OnMouseFirst(LPARAM lParam, WPARAM wParam);
+
+		static BOOL OnLBDown(LPARAM lParam, WPARAM wParam);
+		static BOOL OnLBUp(LPARAM lParam, WPARAM wParam);
+
+		static BOOL OnRBDown(LPARAM lParam, WPARAM wParam);
+		static BOOL OnRBUp(LPARAM lParam, WPARAM wParam);
+
+		static BOOL OnMBDown(LPARAM lParam, WPARAM wParam);
+		static BOOL OnMBUp(LPARAM lParam, WPARAM wParam);
+
+		static BOOL OnXBDown(LPARAM lParam, WPARAM wParam);
+		static BOOL OnXBUp(LPARAM lParam, WPARAM wParam);
+
 	private:
 		static Dvar::Var M_RawInput, M_RawInputVerbose, R_FullScreen, R_AutoPriority;
 		static rawMouseValue_t MouseRawX, MouseRawY;
@@ -31,6 +45,7 @@ namespace Components
 		static bool GetRawInput(LPARAM lParam, RAWINPUT& raw, UINT& dwSize);
 		static BOOL OnRawInput(LPARAM lParam, WPARAM);
 		static bool IsMouseInClientBounds();
+		static BOOL OnLegacyMouseEvent(UINT Msg, LPARAM lParam, WPARAM wParam);
 		static BOOL OnKillFocus(LPARAM lParam, WPARAM);
 		static BOOL OnSetFocus(LPARAM lParam, WPARAM);
 		static void IN_RawMouseMove();

--- a/src/Components/Modules/RawMouse.hpp
+++ b/src/Components/Modules/RawMouse.hpp
@@ -12,7 +12,7 @@ namespace Components
 	private:
 		static Dvar::Var M_RawInput, R_FullScreen, R_AutoPriority;
 		static int MouseRawX, MouseRawY, MouseRawEvents;
-		static bool InRawInput, RawInputSupported;
+		static bool InRawInput;
 
 		static void IN_ClampMouseMove();
 		static void ResetMouseRawEvents();

--- a/src/Components/Modules/RawMouse.hpp
+++ b/src/Components/Modules/RawMouse.hpp
@@ -12,7 +12,7 @@ namespace Components
 	private:
 		static Dvar::Var M_RawInput;
 		static int MouseRawX, MouseRawY;
-		static bool InRawInput, RawInputWasEverEnabled;
+		static bool InRawInput, RawInputWasEverEnabled, RawInputSupported;
 
 		static void IN_ClampMouseMove();
 		static BOOL OnRawInput(LPARAM lParam, WPARAM);

--- a/src/Components/Modules/RawMouse.hpp
+++ b/src/Components/Modules/RawMouse.hpp
@@ -2,6 +2,15 @@
 
 namespace Components
 {
+	struct raw_mouse_value_t
+	{
+		int current = 0;
+		int previous = 0;
+
+		void ResetDelta();
+		int GetDelta() const;
+	};
+
 	class RawMouse : public Component
 	{
 	public:
@@ -11,12 +20,14 @@ namespace Components
 
 	private:
 		static Dvar::Var M_RawInput, R_FullScreen, R_AutoPriority;
-		static int MouseRawX, MouseRawY, MouseRawEvents;
-		static bool InRawInput;
+		static raw_mouse_value_t MouseRawX, MouseRawY;
+		static uint32_t MouseRawEvents;
+		static bool InRawInput, FirstRawInputUpdate;
 
 		static void IN_ClampMouseMove();
 		static void ResetMouseRawEvents();
 		static void ProcessMouseRawEvent(DWORD usButtonFlags, DWORD flag_down, DWORD mouse_event);
+		static bool GetRawInput(LPARAM lParam, RAWINPUT& raw, UINT& dwSize);
 		static BOOL OnRawInput(LPARAM lParam, WPARAM);
 		static bool IsMouseInClientBounds();
 		static BOOL OnKillFocus(LPARAM lParam, WPARAM);

--- a/src/Components/Modules/RawMouse.hpp
+++ b/src/Components/Modules/RawMouse.hpp
@@ -10,7 +10,7 @@ namespace Components
 		static void IN_MouseMove();
 
 	private:
-		static Dvar::Var M_RawInput;
+		static Dvar::Var M_RawInput, R_FullScreen, R_AutoPriority;
 		static int MouseRawX, MouseRawY, MouseRawEvents;
 		static bool InRawInput, RawInputSupported;
 

--- a/src/Components/Modules/RawMouse.hpp
+++ b/src/Components/Modules/RawMouse.hpp
@@ -12,7 +12,7 @@ namespace Components
 	private:
 		static Dvar::Var M_RawInput;
 		static int MouseRawX, MouseRawY, MouseRawEvents;
-		static bool InRawInput, RawInputWasEverEnabled, RawInputSupported;
+		static bool InRawInput, RawInputSupported;
 
 		static void IN_ClampMouseMove();
 		static void ResetMouseRawEvents();

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -226,6 +226,7 @@ namespace Game
 
 	IN_MouseMove_t IN_MouseMove = IN_MouseMove_t(0x64C490);
 	IN_MouseEvent_t IN_MouseEvent = IN_MouseEvent_t(0x4C84D0);
+	IN_Frame_t IN_Frame = IN_Frame_t(0x475E10);
 	IN_Init_t IN_Init = IN_Init_t(0x45D620);
 	IN_Shutdown_t IN_Shutdown = IN_Shutdown_t(0x426360);
 

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -225,6 +225,7 @@ namespace Game
 	IN_RecenterMouse_t IN_RecenterMouse = IN_RecenterMouse_t(0x463D80);
 
 	IN_MouseMove_t IN_MouseMove = IN_MouseMove_t(0x64C490);
+	IN_MouseEvent_t IN_MouseEvent = IN_MouseEvent_t(0x4C84D0);
 	IN_Init_t IN_Init = IN_Init_t(0x45D620);
 	IN_Shutdown_t IN_Shutdown = IN_Shutdown_t(0x426360);
 

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -533,6 +533,9 @@ namespace Game
 	typedef void(*IN_MouseEvent_t)(int flags);
 	extern IN_MouseEvent_t IN_MouseEvent;
 
+	typedef void(*IN_Frame_t)();
+	extern IN_Frame_t IN_Frame;
+
 	typedef void(*IN_Init_t)();
 	extern IN_Init_t IN_Init;
 

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -530,6 +530,9 @@ namespace Game
 	typedef void(*IN_MouseMove_t)();
 	extern IN_MouseMove_t IN_MouseMove;
 
+	typedef void(*IN_MouseEvent_t)(int flags);
+	extern IN_MouseEvent_t IN_MouseEvent;
+
 	typedef void(*IN_Init_t)();
 	extern IN_Init_t IN_Init;
 

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -26,6 +26,8 @@ namespace Game
 
 	MssLocal* milesGlobal = reinterpret_cast<MssLocal*>(0x649A1A0);
 
+	WinVars_t* g_wv = reinterpret_cast<WinVars_t*>(0x64A3AC8);
+
 	const char* origErrorMsg = reinterpret_cast<const char*>(0x79B124);
 
 	XModel* G_GetModel(const int index)

--- a/src/Game/Game.hpp
+++ b/src/Game/Game.hpp
@@ -66,7 +66,7 @@ namespace Game
 	extern NetField* clientStateFields;
 	extern size_t clientStateFieldsCount;
 	extern MssLocal* milesGlobal;
-
+	extern WinVars_t* g_wv;
 
 	extern const char* origErrorMsg;
 

--- a/src/Game/Structs.hpp
+++ b/src/Game/Structs.hpp
@@ -11760,6 +11760,18 @@ namespace Game
 		MssStreamReadInfo streamReadInfo[12];
 	};
 
+	struct WinVars_t
+	{
+		HINSTANCE__* reflib_library;
+		int reflib_active;
+		HWND__* hWnd;
+		HINSTANCE__* hInstance;
+		int activeApp;
+		int isMinimized;
+		int recenterMouse;
+		HHOOK__* lowLevelKeyboardHook;
+		unsigned int sysMsgTime;
+	};
 
 #pragma endregion
 

--- a/src/Game/System.cpp
+++ b/src/Game/System.cpp
@@ -29,12 +29,6 @@ namespace Game
 
 	Sys_QueEvent_t Sys_QueEvent = Sys_QueEvent_t(0x497DE0);
 
-	int &sysMsgTime()
-	{
-		static const DWORD sysMsgTime_t = 0x64A3AE8;
-		return *(int*)sysMsgTime_t;
-	}
-
 	void Sys_QueEvents(int time, int type, int value2, int ptrLength, void* ptr)
 	{
 		Sys_QueEvent(time, type, value2, true, ptrLength, ptr);

--- a/src/Game/System.cpp
+++ b/src/Game/System.cpp
@@ -27,6 +27,20 @@ namespace Game
 	Sys_OutOfMemErrorInternal_t Sys_OutOfMemErrorInternal = Sys_OutOfMemErrorInternal_t(0x4B2E60);
 	Sys_QuitAndStartProcess_t Sys_QuitAndStartProcess = Sys_QuitAndStartProcess_t(0x45FCF0);
 
+	Sys_QueEvent_t Sys_QueEvent = Sys_QueEvent_t(0x497DE0);
+
+	int &sysMsgTime()
+	{
+		static const DWORD sysMsgTime_t = 0x64A3AE8;
+		return *(int*)sysMsgTime_t;
+	}
+
+	void Sys_QueEvents(int time, int type, int value2, int ptrLength, void* ptr)
+	{
+		Sys_QueEvent(time, type, value2, true, ptrLength, ptr);
+		Sys_QueEvent(time, type, value2, false, ptrLength, ptr);
+	}
+
 	char(*sys_exitCmdLine)[1024] = reinterpret_cast<char(*)[1024]>(0x649FB68);
 
 	RTL_CRITICAL_SECTION* s_criticalSection = reinterpret_cast<RTL_CRITICAL_SECTION*>(0x6499BC8);
@@ -60,6 +74,6 @@ namespace Game
 	HANDLE Sys_OpenFileReliable(const char* filename)
 	{
 		return CreateFileA(filename, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING,
-		                   FILE_FLAG_OVERLAPPED | FILE_FLAG_NO_BUFFERING, nullptr);
+			FILE_FLAG_OVERLAPPED | FILE_FLAG_NO_BUFFERING, nullptr);
 	}
 }

--- a/src/Game/System.cpp
+++ b/src/Game/System.cpp
@@ -31,8 +31,8 @@ namespace Game
 
 	void Sys_QueEvents(int time, int type, int value2, int ptrLength, void* ptr)
 	{
-		Sys_QueEvent(time, type, value2, true, ptrLength, ptr);
-		Sys_QueEvent(time, type, value2, false, ptrLength, ptr);
+		Sys_QueEvent(time, type, value2, TRUE, ptrLength, ptr);
+		Sys_QueEvent(time, type, value2, FALSE, ptrLength, ptr);
 	}
 
 	char(*sys_exitCmdLine)[1024] = reinterpret_cast<char(*)[1024]>(0x649FB68);

--- a/src/Game/System.hpp
+++ b/src/Game/System.hpp
@@ -74,9 +74,16 @@ namespace Game
 	typedef void(*Sys_QuitAndStartProcess_t)(const char*);
 	extern Sys_QuitAndStartProcess_t Sys_QuitAndStartProcess;
 
+	typedef void(*Sys_QueEvent_t)(int time, int type, int value, int value2, int ptrLength, void* ptr);
+	extern Sys_QueEvent_t Sys_QueEvent;
+
 	extern char(*sys_exitCmdLine)[1024];
 
 	extern RTL_CRITICAL_SECTION* s_criticalSection;
+
+	extern int& sysMsgTime();
+
+	extern void Sys_QueEvents(int time, int type, int value2, int ptrLength, void* ptr);
 
 	extern void Sys_LockRead(FastCriticalSection* critSect);
 	extern void Sys_UnlockRead(FastCriticalSection* critSect);

--- a/src/Game/System.hpp
+++ b/src/Game/System.hpp
@@ -81,8 +81,6 @@ namespace Game
 
 	extern RTL_CRITICAL_SECTION* s_criticalSection;
 
-	extern int& sysMsgTime();
-
 	extern void Sys_QueEvents(int time, int type, int value2, int ptrLength, void* ptr);
 
 	extern void Sys_LockRead(FastCriticalSection* critSect);


### PR DESCRIPTION
This pull request fixes an fps drop caused by bottleneck of window messages when using high polling rate mouse (8k).

These changes includes RIDEV_NOLEGACY flag to RegisterRawInputDevices, disabling legacy WindowProc messages for input device we register.

I had to fix issues with mouse input when m_raw_input is 0, and also issues that are including with lack of legacy messages 
that i managed to fix with disabling raw input (handling WM_KILLFOCUS, WM_SETFOCUS, mouse going away from client screen space (WM_MOUSELEAVE)).

Since the legacy messages are gone, i made mouse input fully raw when using m_raw_input 1 (handling buttons, scroll).

here is the result (m_raw_input 0 will create fps drops since it uses game's old behaviour):

https://github.com/user-attachments/assets/40b69069-132b-409f-8538-f48cfaeef68a
