### PR TITLE
AntiLag rework

### DIFF
--- a/src/Components/Loader.cpp
+++ b/src/Components/Loader.cpp
@@ -2,6 +2,7 @@
 
 #include "Loader.hpp"
 
+#include "Modules/AntiLag.hpp"
 #include "Modules/ArenaLength.hpp"
 #include "Modules/Auth.hpp"
 #include "Modules/Bans.hpp"
@@ -117,6 +118,7 @@ namespace Components
 
 		Register(new ConfigStrings()); // Needs to be there early !! Before modelcache & weapons
 
+		Register(new AntiLag());
 		Register(new ArenaLength());
 		Register(new AssetHandler());
 		Register(new Bans());

--- a/src/Components/Loader.cpp
+++ b/src/Components/Loader.cpp
@@ -35,6 +35,7 @@
 #include "Modules/MapDump.hpp"
 #include "Modules/MapRotation.hpp"
 #include "Modules/Materials.hpp"
+#include "Modules/Melee.hpp"
 #include "Modules/ModList.hpp"
 #include "Modules/ModelCache.hpp"
 #include "Modules/ModelSurfs.hpp"
@@ -153,6 +154,7 @@ namespace Components
 		Register(new MapRotation());
 		Register(new Maps());
 		Register(new Materials());
+		Register(new Melee());
 		Register(new Menus());
 		Register(new ModList());
 		Register(new ModelCache());

--- a/src/Components/Modules/AntiLag.cpp
+++ b/src/Components/Modules/AntiLag.cpp
@@ -62,7 +62,7 @@ namespace Components
 
 		for (int i = 0; i < Game::level->maxclients; ++i)
 		{
-			auto& ent = Game::g_entities[i];
+			Game::gentity_s& ent = Game::g_entities[i];
 
 			bool clientMoved = clientsMoved[i];
 			if (antiLagMode == 2)
@@ -121,7 +121,7 @@ namespace Components
 
 		for (int i = 0; i < Game::level->maxclients; ++i)
 		{
-			auto& ent = Game::g_entities[i];
+			Game::gentity_s& ent = Game::g_entities[i];
 
 			if (!antilagStore->clientMoved[i]) {
 				continue;

--- a/src/Components/Modules/AntiLag.cpp
+++ b/src/Components/Modules/AntiLag.cpp
@@ -189,7 +189,12 @@ namespace Components
 			Logger::Debug("G_RunMissile: at tick {}, level.time {}\n", Game::level->time + throwingDelay, Game::level->time);
 		}
 
-		AntiLag::G_AntiLagRewindClientPos(missile, Game::level->time + throwingDelay, &antilagStore);
+		uint16_t ownerId = missile->r.ownerNum.number;
+		Game::gentity_s* attacker = nullptr;
+		if (ownerId > 0 && ownerId <= Game::level->maxclients) //
+			attacker = &Game::g_entities[static_cast<int>(ownerId) - 1];
+
+		AntiLag::G_AntiLagRewindClientPos(attacker, Game::level->time + throwingDelay, &antilagStore);
 		Game::G_RunMissileInternal(missile);
 		AntiLag::G_AntiLag_RestoreClientPos(&antilagStore);
 	}

--- a/src/Components/Modules/AntiLag.cpp
+++ b/src/Components/Modules/AntiLag.cpp
@@ -191,8 +191,9 @@ namespace Components
 
 		uint16_t ownerId = missile->r.ownerNum.number;
 		Game::gentity_s* attacker = nullptr;
-		if (ownerId > 0 && ownerId <= Game::level->maxclients) //
+		if (ownerId > 0 && ownerId <= Game::level->maxclients) {
 			attacker = &Game::g_entities[static_cast<int>(ownerId) - 1];
+		}
 
 		AntiLag::G_AntiLagRewindClientPos(attacker, Game::level->time + throwingDelay, &antilagStore);
 		Game::G_RunMissileInternal(missile);

--- a/src/Components/Modules/AntiLag.cpp
+++ b/src/Components/Modules/AntiLag.cpp
@@ -6,40 +6,43 @@ namespace Components
 	Dvar::Var AntiLag::G_AntiLag;
 	Dvar::Var AntiLag::G_AntiLagDebug;
 	bool AntiLag::AntiLagFilled = false;
+	float AntiLag::ColorRed[] = { 1.0f, 0.0f, 0.0f, 1.0f };
+	float AntiLag::ColorGreen[] = { 0.0f, 1.0f, 0.0f, 1.0f };
+	float AntiLag::ColorWhite[] = { 1.0f, 1.0f, 1.0f, 1.0f };
 
-	void __cdecl AntiLag::FireWeapon(Game::gentity_s* ent, int gameTime, int eventType)
+	void AntiLag::FireWeapon(Game::gentity_s* ent, int gameTime, int eventType)
 	{
 		if (G_AntiLag.get<int>() == 0)
 			gameTime = Game::level->time;
 		else if (G_AntiLagDebug.get<int>() != 0)
 			Logger::Debug("FireWeapon: at tick {}, level.time {}\n", gameTime, Game::level->time);
 
-		return Game::FireWeapon(ent, gameTime, eventType);
+		Game::FireWeapon(ent, gameTime, eventType);
 	}
 
-	void __cdecl AntiLag::FireWeaponMelee(Game::gentity_s* ent, int gameTime)
+	void AntiLag::FireWeaponMelee(Game::gentity_s* ent, int gameTime)
 	{
 		if (G_AntiLag.get<int>() == 0)
 			gameTime = Game::level->time;
 		else if (G_AntiLagDebug.get<int>() != 0)
 			Logger::Debug("FireWeaponMelee: at tick {}, level.time {}\n", gameTime, Game::level->time);
 
-		return Game::FireWeaponMelee(ent, gameTime);
+		Game::FireWeaponMelee(ent, gameTime);
 	}
 
-	bool AntiLag::ShouldRewind(uintptr_t stack, uintptr_t returnAddress, Game::gentity_s*& attacker)
+	bool AntiLag::ShouldRewind(uintptr_t stack, uintptr_t returnAddress, Game::gentity_s** attacker)
 	{
 		constexpr uintptr_t Bullet_FireRet = 0x004402E0;
 		constexpr uintptr_t Run_MeleeRet = 0x00501A07;
 		constexpr uintptr_t G_RunMissileRet = 0x004AAD46;
 
 		if (Bullet_FireRet == returnAddress) {
-			attacker = *reinterpret_cast<Game::gentity_s**>(stack + 0x14);
+			*attacker = *reinterpret_cast<Game::gentity_s**>(stack + 0x14);
 			return true;
 		}
 
 		if (Run_MeleeRet == returnAddress) {
-			attacker = *reinterpret_cast<Game::gentity_s**>(stack + 0x10);
+			*attacker = *reinterpret_cast<Game::gentity_s**>(stack + 0x10);
 			return true;
 		}
 
@@ -50,7 +53,7 @@ namespace Components
 			return false;
 		}
 
-		auto projectile = *reinterpret_cast<Game::gentity_s**>(stack + 0x10);
+		Game::gentity_s* projectile = *reinterpret_cast<Game::gentity_s**>(stack + 0x10);
 		if (!projectile)
 		{
 			// no debug check since this is totally unexpected to happen at all.
@@ -60,10 +63,10 @@ namespace Components
 
 		int ownerId = projectile->r.ownerNum.number;
 		if (ownerId > 0 && ownerId <= Game::level->maxclients) //
-			attacker = &Game::g_entities[ownerId - 1];
+			*attacker = &Game::g_entities[ownerId - 1];
 
 		const bool hitGround = projectile->s.groundEntityNum == 0x7FE;
-		auto WeaponDef = Game::BG_GetWeaponDef(projectile->s.weapon);
+		Game::WeaponDef* WeaponDef = Game::BG_GetWeaponDef(projectile->s.weapon);
 
 		// l3d note: this check below does not exist in original iw engine.
 		if (hitGround && (WeaponDef->stickiness == Game::WEAPSTICKINESS_ALL
@@ -77,19 +80,18 @@ namespace Components
 		if (G_AntiLagDebug.get<int>() == 3)
 		{
 			// draw flying projectiles origin
-			std::array<float, 4> clr = { 1.f, 1.f, 1.f, 1.f };
-			std::array<float, 3> org = { 0, 0, 0 };
-			Utils::Maths::VectorScale(projectile->r.box.halfSize, 3, org.data());
-			Utils::Maths::VectorAdd(projectile->r.currentOrigin, org.data(), org.data());
+			float org[3];
+			Utils::Maths::VectorScale(projectile->r.box.halfSize, 3, org);
+			Utils::Maths::VectorAdd(projectile->r.currentOrigin, org, org);
 
 			// draw current origin
-			Game::G_DebugLineWithDuration(org.data(), projectile->r.currentOrigin, clr.data(), 1, 100);
+			Game::G_DebugLineWithDuration(org, projectile->r.currentOrigin, ColorWhite, 1, 100);
 		}
 
 		return true;
 	}
 
-	void __cdecl AntiLag::G_AntiLagRewindClientPos(int gameTime, Game::AntilagClientStore* antilagStore)
+	void AntiLag::G_AntiLagRewindClientPos(int gameTime, Game::AntilagClientStore* antilagStore)
 	{
 		const int antiLagMode = G_AntiLag.get<int>();
 		if (antiLagMode == 0)
@@ -98,7 +100,7 @@ namespace Components
 		Game::gentity_s* attacker = nullptr;
 
 		// get attacker, check if we should run.
-		if (!ShouldRewind(reinterpret_cast<uintptr_t>(_AddressOfReturnAddress()), reinterpret_cast<uintptr_t>(_ReturnAddress()), attacker))
+		if (!ShouldRewind(reinterpret_cast<uintptr_t>(_AddressOfReturnAddress()), reinterpret_cast<uintptr_t>(_ReturnAddress()), &attacker))
 			return;
 
 		antilagStore->Reset();
@@ -144,17 +146,18 @@ namespace Components
 
 			if (G_AntiLagDebug.get<int>() == 3)
 			{
-				std::array<float, 4> clr = { 0.f, 1.f, 0.f, 1.f };
-				std::array<float, 3> org = { ent.r.currentOrigin[0],  ent.r.currentOrigin[1],  ent.r.currentOrigin[2] + ent.r.box.halfSize[2] * 2 };
+				float org[3];
+				Utils::Maths::VectorCopy(ent.r.currentOrigin, org);
+				org[2] += ent.r.box.halfSize[2] * 2;
 
 				// draw current origin
-				Game::G_DebugLineWithDuration(org.data(), ent.r.currentOrigin, clr.data(), 1, 100);
+				Game::G_DebugLineWithDuration(org, ent.r.currentOrigin, ColorRed, 1, 100);
 
-				std::array<float, 4> newclr = { 1.f, 0.f, 0.f, 1.f };
-				std::array<float, 3> neworg = { clientsPositions[i][0],  clientsPositions[i][1],  clientsPositions[i][2] + ent.r.box.halfSize[2] * 2 };
+				Utils::Maths::VectorCopy(clientsPositions[i], org);
+				org[2] += ent.r.box.halfSize[2] * 2;
 
 				// draw lag compensated origin
-				Game::G_DebugLineWithDuration(neworg.data(), clientsPositions[i], newclr.data(), 1, 100);
+				Game::G_DebugLineWithDuration(org, clientsPositions[i], ColorGreen, 1, 100);
 			}
 
 			Utils::Maths::VectorCopy(clientsAngles[i], ent.r.currentAngles);
@@ -171,7 +174,7 @@ namespace Components
 		AntiLag::AntiLagFilled = true;
 	}
 
-	void __cdecl AntiLag::G_AntiLag_RestoreClientPos(Game::AntilagClientStore* antilagStore)
+	void AntiLag::G_AntiLag_RestoreClientPos(Game::AntilagClientStore* antilagStore)
 	{
 		if (!AntiLag::AntiLagFilled)
 			return;

--- a/src/Components/Modules/AntiLag.cpp
+++ b/src/Components/Modules/AntiLag.cpp
@@ -1,0 +1,216 @@
+#include <STDInclude.hpp>
+#include "AntiLag.hpp"
+
+namespace Components
+{
+	Dvar::Var AntiLag::G_AntiLag;
+	Dvar::Var AntiLag::G_AntiLagDebug;
+	bool AntiLag::AntiLagFilled = false;
+
+	void __cdecl AntiLag::FireWeapon(Game::gentity_s* ent, int gameTime, int eventType)
+	{
+		if (G_AntiLag.get<int>() == 0)
+			gameTime = Game::level->time;
+		else if (G_AntiLagDebug.get<int>() != 0)
+			Logger::Debug("FireWeapon: at tick {}, level.time {}\n", gameTime, Game::level->time);
+
+		return Game::FireWeapon(ent, gameTime, eventType);
+	}
+
+	void __cdecl AntiLag::FireWeaponMelee(Game::gentity_s* ent, int gameTime)
+	{
+		if (G_AntiLag.get<int>() == 0)
+			gameTime = Game::level->time;
+		else if (G_AntiLagDebug.get<int>() != 0)
+			Logger::Debug("FireWeaponMelee: at tick {}, level.time {}\n", gameTime, Game::level->time);
+
+		return Game::FireWeaponMelee(ent, gameTime);
+	}
+
+	bool AntiLag::ShouldRewind(uintptr_t stack, uintptr_t returnAddress, Game::gentity_s*& attacker)
+	{
+		constexpr uintptr_t Bullet_FireRet = 0x004402E0;
+		constexpr uintptr_t Run_MeleeRet = 0x00501A07;
+		constexpr uintptr_t G_RunMissileRet = 0x004AAD46;
+
+		if (Bullet_FireRet == returnAddress) {
+			attacker = *reinterpret_cast<Game::gentity_s**>(stack + 0x14);
+			return true;
+		}
+
+		if (Run_MeleeRet == returnAddress) {
+			attacker = *reinterpret_cast<Game::gentity_s**>(stack + 0x10);
+			return true;
+		}
+
+		if (G_RunMissileRet != returnAddress)
+		{
+			// no debug check since this is totally unexpected to happen at all.
+			Logger::Debug("G_AntiLagRewindClientPos called from unknown location...");
+			return false;
+		}
+
+		auto projectile = *reinterpret_cast<Game::gentity_s**>(stack + 0x10);
+		if (!projectile)
+		{
+			// no debug check since this is totally unexpected to happen at all.
+			Logger::Debug("ERROR: G_AntiLagRewindClientPos called from G_RunMissile but has no projectile in stack...");
+			return false;
+		}
+
+		int ownerId = projectile->r.ownerNum.number;
+		if (ownerId > 0 && ownerId <= Game::level->maxclients) //
+			attacker = &Game::g_entities[ownerId - 1];
+
+		const bool hitGround = projectile->s.groundEntityNum == 0x7FE;
+		auto WeaponDef = Game::BG_GetWeaponDef(projectile->s.weapon);
+
+		// l3d note: this check below does not exist in original iw engine.
+		if (hitGround && (WeaponDef->stickiness == Game::WEAPSTICKINESS_ALL
+			|| WeaponDef->stickiness == Game::WEAPSTICKINESS_ALL_ORIENT
+			|| WeaponDef->stickiness == Game::WEAPSTICKINESS_KNIFE))
+		{
+			// we did stick, no need for rewinding anymore.
+			return false;
+		}
+
+		if (G_AntiLagDebug.get<int>() == 3)
+		{
+			// draw flying projectiles origin
+			std::array<float, 4> clr = { 1.f, 1.f, 1.f, 1.f };
+			std::array<float, 3> org = { 0, 0, 0 };
+			Utils::Maths::VectorScale(projectile->r.box.halfSize, 3, org.data());
+			Utils::Maths::VectorAdd(projectile->r.currentOrigin, org.data(), org.data());
+
+			// draw current origin
+			Game::G_DebugLineWithDuration(org.data(), projectile->r.currentOrigin, clr.data(), 1, 100);
+		}
+
+		return true;
+	}
+
+	void __cdecl AntiLag::G_AntiLagRewindClientPos(int gameTime, Game::AntilagClientStore* antilagStore)
+	{
+		const int antiLagMode = G_AntiLag.get<int>();
+		if (antiLagMode == 0)
+			return;
+
+		Game::gentity_s* attacker = nullptr;
+
+		// get attacker, check if we should run.
+		if (!ShouldRewind(reinterpret_cast<uintptr_t>(_AddressOfReturnAddress()), reinterpret_cast<uintptr_t>(_ReturnAddress()), attacker))
+			return;
+
+		antilagStore->Reset();
+
+		// GetClientPositionsAtTime results arrays.
+		std::array<bool, 18> clientsMoved;
+		std::array<Game::vec3_t, 18> clientsAngles;
+		std::array<Game::vec3_t, 18> clientsPositions;
+
+		const int deltaTime = Game::level->time - gameTime;
+		const int targetTime = deltaTime > 400 ? (Game::level->time - 400) : gameTime;
+
+		clientsMoved.fill(false);
+
+		if (!Game::GetClientPositionAtTime(targetTime, clientsPositions.data(), clientsAngles.data(), clientsMoved.data()))
+		{
+			if (G_AntiLagDebug.get<int>() != 0)
+				Logger::Debug("GetClientPositionAtTime failed: tick {}, level.time {}\n", targetTime, Game::level->time);
+
+			return;
+		}
+
+		for (int i = 0; i < Game::level->maxclients; ++i)
+		{
+			auto& ent = Game::g_entities[i];
+
+			bool clientMoved = clientsMoved[i];
+			if (antiLagMode == 2)
+			{
+				// skip teammates here.
+				if (attacker != nullptr && attacker->s.number != ent.s.number && Game::OnSameTeam(attacker, &ent) /*&& src_friendlyFire.get<bool>()*/)
+					clientMoved = false;
+			}
+
+			if (!clientMoved)
+			{
+				antilagStore->clientMoved[i] = false;
+				continue;
+			}
+
+			Utils::Maths::VectorCopy(ent.r.currentOrigin, antilagStore->realClientPositions[i]);
+			Utils::Maths::VectorCopy(ent.r.currentAngles, antilagStore->realClientAngles[i]);
+
+			if (G_AntiLagDebug.get<int>() == 3)
+			{
+				std::array<float, 4> clr = { 0.f, 1.f, 0.f, 1.f };
+				std::array<float, 3> org = { ent.r.currentOrigin[0],  ent.r.currentOrigin[1],  ent.r.currentOrigin[2] + ent.r.box.halfSize[2] * 2 };
+
+				// draw current origin
+				Game::G_DebugLineWithDuration(org.data(), ent.r.currentOrigin, clr.data(), 1, 100);
+
+				std::array<float, 4> newclr = { 1.f, 0.f, 0.f, 1.f };
+				std::array<float, 3> neworg = { clientsPositions[i][0],  clientsPositions[i][1],  clientsPositions[i][2] + ent.r.box.halfSize[2] * 2 };
+
+				// draw lag compensated origin
+				Game::G_DebugLineWithDuration(neworg.data(), clientsPositions[i], newclr.data(), 1, 100);
+			}
+
+			Utils::Maths::VectorCopy(clientsAngles[i], ent.r.currentAngles);
+			Utils::Maths::VectorCopy(clientsPositions[i], ent.r.currentOrigin);
+
+			Game::SV_LinkEntity(&ent);
+
+			if (G_AntiLagDebug.get<int>() == 2)
+				Logger::Debug("antiLag: moving entity ({}) tick {}, level.time {}\n", i, targetTime, Game::level->time);
+
+			antilagStore->clientMoved[i] = true;
+		}
+
+		AntiLag::AntiLagFilled = true;
+	}
+
+	void __cdecl AntiLag::G_AntiLag_RestoreClientPos(Game::AntilagClientStore* antilagStore)
+	{
+		if (!AntiLag::AntiLagFilled)
+			return;
+
+		for (int i = 0; i < Game::level->maxclients; ++i)
+		{
+			auto& ent = Game::g_entities[i];
+
+			if (!antilagStore->clientMoved[i])
+				continue;
+
+			Utils::Maths::VectorCopy(antilagStore->realClientAngles[i], ent.r.currentAngles);
+			Utils::Maths::VectorCopy(antilagStore->realClientPositions[i], ent.r.currentOrigin);
+
+			Game::SV_LinkEntity(&ent);
+
+			antilagStore->clientMoved[i] = false;
+		}
+
+		AntiLag::AntiLagFilled = false;
+	}
+
+	AntiLag::AntiLag()
+	{
+		G_AntiLag = Game::Dvar_RegisterInt("g_antilag", 1, 0, 2, Game::DVAR_CODINFO, "Perform antiLag.\nModes: 1 = original antiLag behaviour, 2 = optimized antiLag.");
+		G_AntiLagDebug = Game::Dvar_RegisterInt("g_antilag_debug", 0, 0, 3, Game::DVAR_CHEAT, "AntiLag debugging: positions and logs.\nModes: 1 = logs, 2 = extended logs, 3 = debug overlays & extended logs.");
+
+		AntiLag::AntiLagFilled = false;
+
+		Utils::Hook(0x5D6D59, AntiLag::FireWeapon, HOOK_CALL).install()->quick();
+		Utils::Hook(0x5D6D6C, AntiLag::FireWeaponMelee, HOOK_CALL).install()->quick();
+
+		Utils::Hook(0x4402DB, AntiLag::G_AntiLagRewindClientPos, HOOK_CALL).install()->quick(); // Bullet_Fire
+		Utils::Hook(0x4404EA, AntiLag::G_AntiLag_RestoreClientPos, HOOK_CALL).install()->quick(); // Bullet_Fire
+
+		Utils::Hook(0x4AAD41, AntiLag::G_AntiLagRewindClientPos, HOOK_CALL).install()->quick(); // Run_Missile
+		Utils::Hook(0x4AAD5C, AntiLag::G_AntiLag_RestoreClientPos, HOOK_CALL).install()->quick(); // Run_Missile
+
+		Utils::Hook(0x501A02, AntiLag::G_AntiLagRewindClientPos, HOOK_CALL).install()->quick(); // Run_Melee (name was guessed)
+		Utils::Hook(0x501A42, AntiLag::G_AntiLag_RestoreClientPos, HOOK_CALL).install()->quick(); // Run_Melee (name was guessed)
+	}
+}

--- a/src/Components/Modules/AntiLag.cpp
+++ b/src/Components/Modules/AntiLag.cpp
@@ -183,6 +183,7 @@ namespace Components
 
 		// i have no idea why it is dereferencing attachModelNames - thats what its actually pointing in this structure...
 		// the structure itself can be wrong. throwingDelay equals negative numbers like -67
+		// 05.12.24 UPD: Caball009 made a PR with fixed gentity_s struct, so this line below starts to point at "missile->entData.missile.antilagTimeOffset"
 		int32_t throwingDelay = *reinterpret_cast<int32_t*>(&missile->attachModelNames[10]);
 
 		if (!AntiLag::IsDisabled() && AntiLag::IsDebugging()) {

--- a/src/Components/Modules/AntiLag.cpp
+++ b/src/Components/Modules/AntiLag.cpp
@@ -148,7 +148,7 @@ namespace Components
 			float org[3];
 			Utils::Maths::VectorCopy(missile->r.currentOrigin, org);
 
-			Game::G_RunItem(missile);
+			Game::G_GeneralLink(missile);
 			Game::G_RunThink(missile);
 
 			if (missileDebugDraw.get<bool>()) {

--- a/src/Components/Modules/AntiLag.cpp
+++ b/src/Components/Modules/AntiLag.cpp
@@ -178,7 +178,7 @@ namespace Components
 		Game::AntilagClientStore antilagStore;
 
 		// i have no idea why it is dereferencing attachModelNames - thats what its actually pointing in this structure...
-		// the structure itself can be wrong
+		// the structure itself can be wrong. throwingDelay equals negative numbers like -67
 		int32_t throwingDelay = *reinterpret_cast<int32_t*>(&missile->attachModelNames[10]);
 
 		if (!AntiLag::IsDisabled() && AntiLag::IsDebugging()) {
@@ -198,9 +198,8 @@ namespace Components
 		AntiLag::AntiLagFilled = false;
 
 		Utils::Hook(0x5D6D59, AntiLag::FireWeapon, HOOK_CALL).install()->quick();
+		Utils::Hook(0x5E4F9E, G_RunMissile, HOOK_CALL).install()->quick(); // #todo: this needs its own file - Missile.cpp...
 
 		// antilag is being called in Melee.cpp and Bullet.cpp now.
-
-		Utils::Hook(0x5E4F9E, G_RunMissile, HOOK_CALL).install()->quick(); // Run_Missile
 	}
 }

--- a/src/Components/Modules/AntiLag.cpp
+++ b/src/Components/Modules/AntiLag.cpp
@@ -68,8 +68,9 @@ namespace Components
 			if (antiLagMode == 2)
 			{
 				// skip teammates here.
-				if (owner != nullptr && owner->s.number != ent.s.number && Game::OnSameTeam(owner, &ent) /*&& src_friendlyFire.get<bool>()*/)
+				if (owner != nullptr && owner->s.number != ent.s.number && Game::OnSameTeam(owner, &ent) /*&& src_friendlyFire.get<bool>()*/) {
 					clientMoved = false;
+				}
 			}
 
 			if (!clientMoved)
@@ -158,13 +159,16 @@ namespace Components
 		}
 
 		Game::WeaponDef* WeaponDef = Game::BG_GetWeaponDef(missile->s.weapon);
-		bool isThrowingKnife = WeaponDef->weapClass == Game::WEAPCLASS_THROWINGKNIFE;
+
 		const bool hitGround = missile->s.groundEntityNum == 0x7FE;
+		const bool canStick = (WeaponDef->stickiness == Game::WEAPSTICKINESS_ALL
+			|| WeaponDef->stickiness == Game::WEAPSTICKINESS_ALL_ORIENT
+			|| WeaponDef->stickiness == Game::WEAPSTICKINESS_KNIFE);
+
+		bool isThrowingKnife = WeaponDef->weapClass == Game::WEAPCLASS_THROWINGKNIFE;
 
 		// l3d note: this check below does not exist in original iw engine.
-		if (hitGround && (WeaponDef->stickiness == Game::WEAPSTICKINESS_ALL
-			|| WeaponDef->stickiness == Game::WEAPSTICKINESS_ALL_ORIENT
-			|| WeaponDef->stickiness == Game::WEAPSTICKINESS_KNIFE))
+		if (isThrowingKnife && hitGround && canStick)
 		{
 			// we did stick, no need for rewinding anymore.
 			isThrowingKnife = false;

--- a/src/Components/Modules/AntiLag.cpp
+++ b/src/Components/Modules/AntiLag.cpp
@@ -181,10 +181,7 @@ namespace Components
 
 		Game::AntilagClientStore antilagStore;
 
-		// i have no idea why it is dereferencing attachModelNames - thats what its actually pointing in this structure...
-		// the structure itself can be wrong. throwingDelay equals negative numbers like -67
-		// 05.12.24 UPD: Caball009 made a PR with fixed gentity_s struct, so this line below starts to point at "missile->entData.missile.antilagTimeOffset"
-		int32_t throwingDelay = *reinterpret_cast<int32_t*>(&missile->attachModelNames[10]);
+		int32_t throwingDelay = missile->entData.missile.antilagTimeOffset;
 
 		if (!AntiLag::IsDisabled() && AntiLag::IsDebugging()) {
 			Logger::Debug("G_RunMissile: at tick {}, level.time {}\n", Game::level->time + throwingDelay, Game::level->time);

--- a/src/Components/Modules/AntiLag.hpp
+++ b/src/Components/Modules/AntiLag.hpp
@@ -7,14 +7,17 @@ namespace Components
 	public:
 		AntiLag();
 
-		static void __cdecl FireWeapon(Game::gentity_s* ent, int gameTime, int a3);
-		static void __cdecl FireWeaponMelee(Game::gentity_s* ent, int gameTime);
-		static void __cdecl G_AntiLagRewindClientPos(int gameTime, Game::AntilagClientStore* antilagStore);
-		static void __cdecl G_AntiLag_RestoreClientPos(Game::AntilagClientStore* antilagStore);
+		static void FireWeapon(Game::gentity_s* ent, int gameTime, int a3);
+		static void FireWeaponMelee(Game::gentity_s* ent, int gameTime);
+		static void G_AntiLagRewindClientPos(int gameTime, Game::AntilagClientStore* antilagStore);
+		static void G_AntiLag_RestoreClientPos(Game::AntilagClientStore* antilagStore);
 
-		static bool ShouldRewind(uintptr_t stack, uintptr_t returnAddress, Game::gentity_s*& attacker);
+		static bool ShouldRewind(uintptr_t stack, uintptr_t returnAddress, Game::gentity_s** attacker);
 
 		static Dvar::Var G_AntiLag, G_AntiLagDebug;
 		static bool AntiLagFilled;
+		static float ColorRed[];
+		static float ColorGreen[];
+		static float ColorWhite[];
 	};
 }

--- a/src/Components/Modules/AntiLag.hpp
+++ b/src/Components/Modules/AntiLag.hpp
@@ -8,11 +8,14 @@ namespace Components
 		AntiLag();
 
 		static void FireWeapon(Game::gentity_s* ent, int gameTime, int a3);
-		static void FireWeaponMelee(Game::gentity_s* ent, int gameTime);
-		static void G_AntiLagRewindClientPos(int gameTime, Game::AntilagClientStore* antilagStore);
+
+		static void G_AntiLagRewindClientPos(Game::gentity_s* owner, int gameTime, Game::AntilagClientStore* antilagStore);
 		static void G_AntiLag_RestoreClientPos(Game::AntilagClientStore* antilagStore);
 
 		static bool ShouldRewind(uintptr_t stack, uintptr_t returnAddress, Game::gentity_s** attacker);
+
+		static bool IsDisabled();
+		static bool IsDebugging(const int mode = 1);
 
 		static Dvar::Var G_AntiLag, G_AntiLagDebug;
 		static bool AntiLagFilled;

--- a/src/Components/Modules/AntiLag.hpp
+++ b/src/Components/Modules/AntiLag.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace Components
+{
+	class AntiLag : public Component
+	{
+	public:
+		AntiLag();
+
+		static void __cdecl FireWeapon(Game::gentity_s* ent, int gameTime, int a3);
+		static void __cdecl FireWeaponMelee(Game::gentity_s* ent, int gameTime);
+		static void __cdecl G_AntiLagRewindClientPos(int gameTime, Game::AntilagClientStore* antilagStore);
+		static void __cdecl G_AntiLag_RestoreClientPos(Game::AntilagClientStore* antilagStore);
+
+		static bool ShouldRewind(uintptr_t stack, uintptr_t returnAddress, Game::gentity_s*& attacker);
+
+		static Dvar::Var G_AntiLag, G_AntiLagDebug;
+		static bool AntiLagFilled;
+	};
+}

--- a/src/Components/Modules/Bullet.cpp
+++ b/src/Components/Modules/Bullet.cpp
@@ -132,10 +132,10 @@ namespace Components
 		BG_srand_Hk(&randomSeed);
 
 		Dvar::Var g_debugBullet(0x19BD624);
-		Game::BulletContext_t bulletContext;
+		Game::BulletFireParams bulletContext;
 		const int weaponIndex = weaponEnt ? weaponEnt->s.number : 0x7FE;
 
-		Game::BulletTrace_t bulletTr;
+		Game::BulletTraceResults bulletTr;
 
 		for (; nBullets > 0; nBullets--)
 		{
@@ -143,15 +143,15 @@ namespace Components
 			bulletContext.Init(weaponIndex, wpParms);
 			bulletContext.methodOfDeath = Game::Bullet_GetMethodOfDeath(perks, wpParms->weapDef);
 
-			Game::Bullet_Endpos(&randomSeed, spread, bulletContext.endPos, bulletContext.muzzleDir, wpParms, fMinDamageRange);
+			Game::Bullet_Endpos(&randomSeed, spread, bulletContext.end, bulletContext.dir, wpParms, fMinDamageRange);
 
 			if (g_debugBullet.get<int>() == 1) {
-				Game::G_DebugLineWithDuration(bulletContext.startPos, bulletContext.endPos, ColorWhite, 1, 100);
+				Game::G_DebugLineWithDuration(bulletContext.origStart, bulletContext.end, ColorWhite, 1, 100);
 			}
 
 			if (Game::BG_WeaponBulletFire_ShouldPenetrate(perks, wpParms->weapDef))
 			{
-				Game::Bullet_PenetrationTrace(&randomSeed, &bulletContext, &bulletTr, wpParms->weaponIndex, attacker, gameTime);
+				Game::Bullet_FirePenetrate(&randomSeed, &bulletContext, &bulletTr, wpParms->weaponIndex, attacker, gameTime);
 				continue;
 			}
 
@@ -168,7 +168,7 @@ namespace Components
 				push    eax
 				mov     eax, attacker
 				lea     ecx, bulletTr
-				call    Game::Bullet_SpreadTrace
+				call    Game::Bullet_FireExtended
 				add     esp, 10h
 			}
 		}

--- a/src/Components/Modules/Bullet.cpp
+++ b/src/Components/Modules/Bullet.cpp
@@ -87,7 +87,7 @@ namespace Components
 		float spread,
 		Game::weaponParms* wpParms,
 		Game::gentity_s* weaponEnt,
-		int unkBool,
+		Game::PlayerHandIndex handIndex,
 		int gameTime)
 	{
 		Game::AntilagClientStore antiLag_Backup;
@@ -125,8 +125,9 @@ namespace Components
 		}
 
 		uint32_t randomSeed = gameTime;
-		if (unkBool)
+		if (handIndex) {
 			randomSeed = gameTime + 10;
+		}
 
 		BG_srand_Hk(&randomSeed);
 
@@ -144,8 +145,9 @@ namespace Components
 
 			Game::Bullet_Endpos(&randomSeed, spread, bulletContext.endPos, bulletContext.muzzleDir, wpParms, fMinDamageRange);
 
-			if (g_debugBullet.get<int>() == 1)
+			if (g_debugBullet.get<int>() == 1) {
 				Game::G_DebugLineWithDuration(bulletContext.startPos, bulletContext.endPos, ColorWhite, 1, 100);
+			}
 
 			if (Game::BG_WeaponBulletFire_ShouldPenetrate(perks, wpParms->weapDef))
 			{

--- a/src/Components/Modules/Bullet.cpp
+++ b/src/Components/Modules/Bullet.cpp
@@ -83,8 +83,17 @@ namespace Components
 		std::memcpy(CalcRicochetSave, result, sizeof(float[3]));
 	}
 
-	int Bullet::Bullet_Fire_Stub(Game::gentity_s* attacker, [[maybe_unused]] float spread, Game::weaponParms* wp, Game::gentity_s* weaponEnt, Game::PlayerHandIndex hand, int gameTime)
+	int Bullet::Bullet_Fire(Game::gentity_s* attacker,
+		float spread,
+		Game::weaponParms* wpParms,
+		Game::gentity_s* weaponEnt,
+		int unkBool,
+		int gameTime)
 	{
+		Game::AntilagClientStore antiLag_Backup;
+		AntiLag::G_AntiLagRewindClientPos(attacker, gameTime, &antiLag_Backup);
+
+#ifdef DEBUG_RIOT_SHIELD
 		float tmp[3];
 
 		Game::G_DebugStar(ContactPointSave, ColorYellow);
@@ -96,20 +105,8 @@ namespace Components
 		Game::G_DebugLineWithDuration(VCSave, tmp, ColorOrange, 1, 100);
 		Game::G_DebugStar(tmp, ColorBlue);
 
-		// Set the spread to 0 when drawing
-		return Game::Bullet_Fire(attacker, 0.0f, wp, weaponEnt, hand, gameTime);
-	}
-
-	int Bullet::Bullet_Fire(Game::gentity_s* attacker,
-		float spread,
-		Game::weaponParms* wpParms,
-		Game::gentity_s* weaponEnt,
-		int unkBool,
-		int gameTime)
-	{
-		Game::AntilagClientStore antiLag_Backup;
-		AntiLag::G_AntiLagRewindClientPos(attacker, gameTime, &antiLag_Backup);
-
+		spread = 0;
+#endif
 		uint32_t perks[2] = { 0,0 };
 
 		if (attacker->client) {
@@ -227,8 +224,6 @@ namespace Components
 		Utils::Hook(0x5D5BBA, CalcRicochet_Stub, HOOK_CALL).install()->quick();
 
 		Utils::Hook(0x5D5BD7, _VectorMA_Stub, HOOK_CALL).install()->quick();
-
-		Utils::Hook(0x5D5C0B, Bullet_Fire_Stub, HOOK_CALL).install()->quick();
 #endif
 	}
 }

--- a/src/Components/Modules/Bullet.cpp
+++ b/src/Components/Modules/Bullet.cpp
@@ -133,9 +133,6 @@ namespace Components
 
 		BG_srand_Hk(&randomSeed);
 
-		if (nBullets <= 0)
-			return -1;
-
 		Dvar::Var g_debugBullet(0x19BD624);
 		Game::BulletContext_t bulletContext;
 		const int weaponIndex = weaponEnt ? weaponEnt->s.number : 0x7FE;
@@ -146,7 +143,7 @@ namespace Components
 		{
 			// #TODO: should we move Init out of iteration for optimization? (current code is IW4 copy)
 			bulletContext.Init(weaponIndex, wpParms);
-			bulletContext.bulletMethodOfDeath = Game::Bullet_GetMethodOfDeath(perks, wpParms->weapDef);
+			bulletContext.methodOfDeath = Game::Bullet_GetMethodOfDeath(perks, wpParms->weapDef);
 
 			Game::Bullet_Endpos(&randomSeed, spread, bulletContext.endPos, bulletContext.muzzleDir, wpParms, fMinDamageRange);
 
@@ -179,7 +176,7 @@ namespace Components
 
 		if (ShouldSpread)
 		{
-			float spreadDummy = 0, rangeDummy = 0;
+			float spreadDummy = 0, rangeDummy = 0; // required for fstp instruction
 			__asm
 			{
 				mov     ecx, weaponEnt

--- a/src/Components/Modules/Bullet.cpp
+++ b/src/Components/Modules/Bullet.cpp
@@ -1,4 +1,5 @@
 #include "Bullet.hpp"
+#include "AntiLag.hpp"
 
 namespace Components
 {
@@ -9,9 +10,10 @@ namespace Components
 	float Bullet::VCSave[3];
 	float Bullet::CalcRicochetSave[3];
 
-	float Bullet::ColorYellow[] = {1.0f, 1.0f, 0.0f, 1.0f};
-	float Bullet::ColorBlue[] = {0.0f, 0.0f, 1.0f, 1.0f};
-	float Bullet::ColorOrange[] = {1.0f, 0.7f, 0.0f, 1.0f};
+	float Bullet::ColorYellow[] = { 1.0f, 1.0f, 0.0f, 1.0f };
+	float Bullet::ColorBlue[] = { 0.0f, 0.0f, 1.0f, 1.0f };
+	float Bullet::ColorOrange[] = { 1.0f, 0.7f, 0.0f, 1.0f };
+	float Bullet::ColorWhite[] = { 1.0f, 1.0f, 1.0f, 1.0f };
 
 	float Bullet::BG_GetSurfacePenetrationDepthStub(const Game::WeaponDef* weapDef, int surfaceType)
 	{
@@ -36,20 +38,6 @@ namespace Components
 		return 0.0f;
 	}
 
-	__declspec(naked) void Bullet::Bullet_FireStub()
-	{
-		__asm
-		{
-			push eax
-			mov eax, BGBulletRange
-			fld dword ptr [eax + 0x10] // dvar_t.current.value
-			pop eax
-
-			push 0x440346
-			retn
-		}
-	}
-
 	void Bullet::BG_srand_Hk(unsigned int* pHoldrand)
 	{
 		*pHoldrand = static_cast<unsigned int>(std::rand());
@@ -65,7 +53,7 @@ namespace Components
 		__asm
 		{
 			pushad
-			push [esp + 0x20 + 0xC]
+			push[esp + 0x20 + 0xC]
 			call BulletRicochet_Save
 			add esp, 0x4
 			popad
@@ -73,7 +61,7 @@ namespace Components
 			// Game's code
 			sub esp, 0x4C
 			push ebp
-			mov ebp, dword ptr [esp + 0x60]
+			mov ebp, dword ptr[esp + 0x60]
 
 			push 0x5D5B08
 			ret
@@ -112,6 +100,107 @@ namespace Components
 		return Game::Bullet_Fire(attacker, 0.0f, wp, weaponEnt, hand, gameTime);
 	}
 
+	int Bullet::Bullet_Fire(Game::gentity_s* attacker,
+		float spread,
+		Game::weaponParms* wpParms,
+		Game::gentity_s* weaponEnt,
+		int unkBool,
+		int gameTime)
+	{
+		Game::AntilagClientStore antiLag_Backup;
+		AntiLag::G_AntiLagRewindClientPos(attacker, gameTime, &antiLag_Backup);
+
+		uint32_t perks[2] = { 0,0 };
+
+		if (attacker->client) {
+			perks[0] = attacker->client->ps.perks[0];
+			perks[1] = attacker->client->ps.perks[1];
+		}
+
+		float fMinDamageRange = Bullet::BGBulletRange->current.value;
+		int32_t nBullets = 1;
+
+		const bool ShouldSpread = Game::BG_WeaponBulletFire_ShouldSpread(perks, wpParms->weapDef);
+		if (ShouldSpread)
+		{
+			fMinDamageRange = wpParms->weapDef->fMinDamageRange;
+			nBullets = wpParms->weapDef->shotCount - 1;
+		}
+
+		uint32_t randomSeed = gameTime;
+		if (unkBool)
+			randomSeed = gameTime + 10;
+
+		BG_srand_Hk(&randomSeed);
+
+		if (nBullets <= 0)
+			return -1;
+
+		Dvar::Var g_debugBullet(0x19BD624);
+		Game::BulletContext_t bulletContext;
+		const int weaponIndex = weaponEnt ? weaponEnt->s.number : 0x7FE;
+
+		Game::BulletTrace_t bulletTr;
+
+		for (; nBullets > 0; nBullets--)
+		{
+			// #TODO: should we move Init out of iteration for optimization? (current code is IW4 copy)
+			bulletContext.Init(weaponIndex, wpParms);
+			bulletContext.bulletMethodOfDeath = Game::Bullet_GetMethodOfDeath(perks, wpParms->weapDef);
+
+			Game::Bullet_Endpos(&randomSeed, spread, bulletContext.endPos, bulletContext.muzzleDir, wpParms, fMinDamageRange);
+
+			if (g_debugBullet.get<int>() == 1)
+				Game::G_DebugLineWithDuration(bulletContext.startPos, bulletContext.endPos, ColorWhite, 1, 100);
+
+			if (Game::BG_WeaponBulletFire_ShouldPenetrate(perks, wpParms->weapDef))
+			{
+				Game::Bullet_PenetrationTrace(&randomSeed, &bulletContext, &bulletTr, wpParms->weaponIndex, attacker, gameTime);
+				continue;
+			}
+
+			__asm
+			{
+				mov     eax, gameTime
+				push    eax
+				mov     eax, [ebp + 10h]
+				mov     ecx, [eax + 3Ch]
+				push    ecx
+				lea     edx, bulletContext
+				push    edx
+				lea     eax, randomSeed
+				push    eax
+				mov     eax, attacker
+				lea     ecx, bulletTr
+				call    Game::Bullet_SpreadTrace
+				add     esp, 10h
+			}
+		}
+
+		if (ShouldSpread)
+		{
+			float spreadDummy = 0, rangeDummy = 0;
+			__asm
+			{
+				mov     ecx, weaponEnt
+				push    ecx
+				fld		spread
+				mov		esi, wpParms
+				push    esi
+				sub     esp, 8
+				fstp	spreadDummy
+				mov     eax, attacker
+				fld		fMinDamageRange
+				fstp	rangeDummy
+				call    Game::Bullet_ShotgunSpread
+				add     esp, 10h
+			}
+		}
+
+		AntiLag::G_AntiLag_RestoreClientPos(&antiLag_Backup);
+		return -1;
+	}
+
 	Bullet::Bullet()
 	{
 		BGSurfacePenetration = Dvar::Register<float>("bg_surfacePenetration", 0.0f,
@@ -120,9 +209,15 @@ namespace Components
 			0.0f, std::numeric_limits<float>::max(), Game::DVAR_CODINFO, "Max range used when calculating the bullet end position");
 
 		Utils::Hook(0x4F6980, BG_GetSurfacePenetrationDepthStub, HOOK_JUMP).install()->quick();
-		Utils::Hook(0x440340, Bullet_FireStub, HOOK_JUMP).install()->quick();
 
-		Utils::Hook(0x440368, BG_srand_Hk, HOOK_CALL).install()->quick();
+		// we dont need this anymore since we rebuild Bullet_Fire
+		//Utils::Hook(0x440368, BG_srand_Hk, HOOK_CALL).install()->quick();
+
+		Utils::Hook(0x4A4E6B, Bullet_Fire, HOOK_CALL).install()->quick(); // FireWeapon
+		Utils::Hook(0x4E24D0, Bullet_Fire, HOOK_CALL).install()->quick(); // VehCmd_FireWeapon
+		Utils::Hook(0x498167, Bullet_Fire, HOOK_CALL).install()->quick(); // Scr_MagicBullet
+		Utils::Hook(0x5FF174, Bullet_Fire, HOOK_CALL).install()->quick(); // Turret_Shoot_internal
+		Utils::Hook(0x5D5C0B, Bullet_Fire, HOOK_CALL).install()->quick(); // Riot Shield related.
 
 		std::memset(ContactPointSave, 0, sizeof(float[3]));
 		std::memset(VCSave, 0, sizeof(float[3]));

--- a/src/Components/Modules/Bullet.hpp
+++ b/src/Components/Modules/Bullet.hpp
@@ -5,6 +5,8 @@ namespace Components
 	class Bullet : public Component
 	{
 	public:
+		static int Bullet_Fire(Game::gentity_s* attacker, float spread, Game::weaponParms* weaponParms, Game::gentity_s* weaponEnt, int extrapolate_or_smth, int gameTime);
+
 		Bullet();
 
 	private:
@@ -19,10 +21,9 @@ namespace Components
 		static float ColorYellow[];
 		static float ColorBlue[];
 		static float ColorOrange[];
+		static float ColorWhite[];
 
 		static float BG_GetSurfacePenetrationDepthStub(const Game::WeaponDef* weapDef, int surfaceType);
-
-		static void Bullet_FireStub();
 
 		static void BG_srand_Hk(unsigned int* pHoldrand);
 

--- a/src/Components/Modules/Bullet.hpp
+++ b/src/Components/Modules/Bullet.hpp
@@ -24,7 +24,7 @@ namespace Components
 		static float BG_GetSurfacePenetrationDepthStub(const Game::WeaponDef* weapDef, int surfaceType);
 
 		static void BG_srand_Hk(unsigned int* pHoldrand);
-		static int Bullet_Fire(Game::gentity_s* attacker, float spread, Game::weaponParms* weaponParms, Game::gentity_s* weaponEnt, int extrapolate_or_smth, int gameTime);
+		static int Bullet_Fire(Game::gentity_s* attacker, float spread, Game::weaponParms* weaponParms, Game::gentity_s* weaponEnt, Game::PlayerHandIndex handIndex, int gameTime);
 
 		static void BulletRicochet_Save(const float* contactPoint);
 		static void BulletRicochet_Stub();

--- a/src/Components/Modules/Bullet.hpp
+++ b/src/Components/Modules/Bullet.hpp
@@ -5,8 +5,6 @@ namespace Components
 	class Bullet : public Component
 	{
 	public:
-		static int Bullet_Fire(Game::gentity_s* attacker, float spread, Game::weaponParms* weaponParms, Game::gentity_s* weaponEnt, int extrapolate_or_smth, int gameTime);
-
 		Bullet();
 
 	private:
@@ -26,6 +24,7 @@ namespace Components
 		static float BG_GetSurfacePenetrationDepthStub(const Game::WeaponDef* weapDef, int surfaceType);
 
 		static void BG_srand_Hk(unsigned int* pHoldrand);
+		static int Bullet_Fire(Game::gentity_s* attacker, float spread, Game::weaponParms* weaponParms, Game::gentity_s* weaponEnt, int extrapolate_or_smth, int gameTime);
 
 		static void BulletRicochet_Save(const float* contactPoint);
 		static void BulletRicochet_Stub();
@@ -33,7 +32,5 @@ namespace Components
 		static void CalcRicochet_Stub(const float* incoming, const float* normal, float* result);
 
 		static void _VectorMA_Stub(float* va, float scale, float* vb, float* vc);
-
-		static int Bullet_Fire_Stub(Game::gentity_s* attacker, float spread, Game::weaponParms* wp, Game::gentity_s* weaponEnt, Game::PlayerHandIndex hand, int gameTime);
 	};
 }

--- a/src/Components/Modules/Bullet.hpp
+++ b/src/Components/Modules/Bullet.hpp
@@ -9,6 +9,7 @@ namespace Components
 
 	private:
 		static Dvar::Var BGSurfacePenetration;
+		static Dvar::Var DebugRiotShield;
 		// Can't use Var class inside assembly stubs
 		static Game::dvar_t* BGBulletRange;
 

--- a/src/Components/Modules/Melee.cpp
+++ b/src/Components/Modules/Melee.cpp
@@ -1,0 +1,139 @@
+#include <STDInclude.hpp>
+#include "Melee.hpp"
+#include "AntiLag.hpp"
+
+namespace Components
+{
+	void Melee::FireWeaponMelee(Game::gentity_s* ent, int gameTime)
+	{
+		if (AntiLag::IsDisabled()) {
+			gameTime = Game::level->time;
+		}
+		else if (AntiLag::IsDebugging()) {
+			Logger::Debug("FireWeaponMelee: at tick {}, level.time {}\n", gameTime, Game::level->time);
+		}
+
+		Game::FireWeaponMelee(ent, gameTime);
+	}
+
+	Game::gentity_s* Melee_Trace(
+		Game::gentity_s* attacker,
+		Game::weaponParms* wpParms,
+		float player_meleeRange,
+		float player_meleeWidth,
+		float player_meleeHeight)
+	{
+		float hitPoint[3];
+		Game::trace_t tr;
+
+		auto weapDef = wpParms->weapDef;
+		int iMeleeDamage = weapDef->iMeleeDamage;
+		if (!Game::Melee_Trace_Internal(
+			attacker,
+			wpParms,
+			iMeleeDamage,
+			player_meleeRange,
+			player_meleeWidth,
+			player_meleeHeight,
+			&tr,
+			hitPoint))
+		{
+			return nullptr;
+		}
+
+		// game does not check if entityHitId is valid, should we start to do it for safer code?
+		int entityHitId = Game::Trace_GetEntityHitId(&tr);
+		auto hitEntity = &Game::g_entities[entityHitId];
+		const bool specialPartgroup = tr.partGroup == 19;
+
+		if (attacker->client && hitEntity->client && !specialPartgroup)
+		{
+			Game::G_AddEvent(attacker, Game::EV_MELEE_BLOOD, 0);
+		}
+
+		const Game::entity_event_t entityEvent = !hitEntity->client ? Game::EV_MELEE_MISS : Game::EV_MELEE_HIT;
+		Game::gentity_s* meleeTempEvent = Game::G_TempEntity(hitPoint, entityEvent);
+
+		meleeTempEvent->s.otherEntityNum = hitEntity->s.number;
+		meleeTempEvent->s.weapon = attacker->s.weapon;
+		meleeTempEvent->s.un2.__s1.weaponModel = attacker->s.un2.__s1.weaponModel;
+		meleeTempEvent->s.eventParm = 0;
+
+		if (weapDef->knifeModel && attacker->client)
+			meleeTempEvent->s.eventParm = 1;
+		if (specialPartgroup)
+			meleeTempEvent->s.eventParm |= 2u;
+
+		if (hitEntity->s.number == 0x7FE || !hitEntity->takedamage)
+			return nullptr;
+
+		float endPoint[3];
+		endPoint[0] = wpParms->forward[0];
+		endPoint[1] = wpParms->forward[1];
+		endPoint[2] = wpParms->forward[2] + 0.25f;
+
+		int		 damageRand = (int)rand() % 5 + iMeleeDamage;
+		uint16_t partName = tr.partName;
+		uint16_t partGroup = tr.partGroup;
+
+		if (specialPartgroup)
+		{
+			partName = *reinterpret_cast<uint16_t*>(0x1AA2E7A);
+			partGroup = 0;
+
+			if (hitEntity->client)
+			{
+				Game::G_ShieldNotifyAndDamage(
+					hitEntity,
+					attacker,
+					attacker,
+					endPoint,
+					hitPoint,
+					damageRand,
+					16,
+					8,
+					-1,
+					0);
+				return hitEntity;
+			}
+		}
+
+		Game::G_Damage(
+			hitEntity,
+			attacker,
+			attacker,
+			endPoint,
+			hitPoint,
+			damageRand,
+			specialPartgroup ? 16 : 0,
+			8u,
+			-1,
+			partGroup,
+			tr.modelIndex,
+			partName,
+			0);
+
+		return hitEntity;
+	}
+
+	void Melee::Weapon_Melee(
+		Game::gentity_s* attacker,
+		Game::weaponParms* wpParms,
+		float player_meleeRange,
+		float player_meleeWidth,
+		float player_meleeHeight,
+		int gameTime)
+	{
+		Game::AntilagClientStore antilagStore;
+
+		AntiLag::G_AntiLagRewindClientPos(attacker, gameTime, &antilagStore);
+		Melee_Trace(attacker, wpParms, player_meleeRange, player_meleeWidth, player_meleeHeight);
+		AntiLag::G_AntiLag_RestoreClientPos(&antilagStore);
+	}
+
+	Melee::Melee()
+	{
+		Utils::Hook(0x5D6D6C, Melee::FireWeaponMelee, HOOK_CALL).install()->quick();
+		Utils::Hook(0x4F251F, Weapon_Melee, HOOK_CALL).install()->quick(); // Weapon_Melee
+	}
+}

--- a/src/Components/Modules/Melee.cpp
+++ b/src/Components/Modules/Melee.cpp
@@ -16,7 +16,7 @@ namespace Components
 		Game::FireWeaponMelee(ent, gameTime);
 	}
 
-	Game::gentity_s* Melee_Trace(
+	Game::gentity_s* Melee::Melee_Trace(
 		Game::gentity_s* attacker,
 		Game::weaponParms* wpParms,
 		float player_meleeRange,
@@ -26,7 +26,7 @@ namespace Components
 		float hitPoint[3];
 		Game::trace_t tr;
 
-		auto weapDef = wpParms->weapDef;
+		const Game::WeaponDef* weapDef = wpParms->weapDef;
 		int iMeleeDamage = weapDef->iMeleeDamage;
 		if (!Game::Melee_Trace_Internal(
 			attacker,
@@ -42,8 +42,8 @@ namespace Components
 		}
 
 		// game does not check if entityHitId is valid, should we start to do it for safer code?
-		int entityHitId = Game::Trace_GetEntityHitId(&tr);
-		auto hitEntity = &Game::g_entities[entityHitId];
+		uint16_t entityHitId = Game::Trace_GetEntityHitId(&tr);
+		Game::gentity_s* hitEntity = &Game::g_entities[entityHitId];
 		const bool specialPartgroup = tr.partGroup == 19;
 
 		if (attacker->client && hitEntity->client && !specialPartgroup) {
@@ -129,7 +129,7 @@ namespace Components
 		Game::AntilagClientStore antilagStore;
 
 		AntiLag::G_AntiLagRewindClientPos(attacker, gameTime, &antilagStore);
-		Melee_Trace(attacker, wpParms, player_meleeRange, player_meleeWidth, player_meleeHeight);
+		Melee::Melee_Trace(attacker, wpParms, player_meleeRange, player_meleeWidth, player_meleeHeight);
 		AntiLag::G_AntiLag_RestoreClientPos(&antilagStore);
 	}
 

--- a/src/Components/Modules/Melee.cpp
+++ b/src/Components/Modules/Melee.cpp
@@ -78,7 +78,7 @@ namespace Components
 
 		if (specialPartgroup)
 		{
-			partName = *reinterpret_cast<uint16_t*>(0x1AA2E7A);
+			partName = *Game::PartName_None;
 			partGroup = 0;
 
 			if (hitEntity->client)

--- a/src/Components/Modules/Melee.cpp
+++ b/src/Components/Modules/Melee.cpp
@@ -46,8 +46,7 @@ namespace Components
 		auto hitEntity = &Game::g_entities[entityHitId];
 		const bool specialPartgroup = tr.partGroup == 19;
 
-		if (attacker->client && hitEntity->client && !specialPartgroup)
-		{
+		if (attacker->client && hitEntity->client && !specialPartgroup) {
 			Game::G_AddEvent(attacker, Game::EV_MELEE_BLOOD, 0);
 		}
 
@@ -59,13 +58,16 @@ namespace Components
 		meleeTempEvent->s.un2.__s1.weaponModel = attacker->s.un2.__s1.weaponModel;
 		meleeTempEvent->s.eventParm = 0;
 
-		if (weapDef->knifeModel && attacker->client)
+		if (weapDef->knifeModel && attacker->client) {
 			meleeTempEvent->s.eventParm = 1;
-		if (specialPartgroup)
+		}
+		if (specialPartgroup) {
 			meleeTempEvent->s.eventParm |= 2u;
+		}
 
-		if (hitEntity->s.number == 0x7FE || !hitEntity->takedamage)
+		if (hitEntity->s.number == 0x7FE || !hitEntity->takedamage) {
 			return nullptr;
+		}
 
 		float endPoint[3];
 		endPoint[0] = wpParms->forward[0];

--- a/src/Components/Modules/Melee.hpp
+++ b/src/Components/Modules/Melee.hpp
@@ -7,7 +7,9 @@ namespace Components
 	public:
 		Melee();
 
+	private:
 		static void Weapon_Melee(Game::gentity_s* attacker, Game::weaponParms* wpParms, float player_meleeRange, float player_meleeWidth, float player_meleeHeight, int gameTime);
 		static void FireWeaponMelee(Game::gentity_s* ent, int gameTime);
+		static Game::gentity_s* Melee_Trace(Game::gentity_s* attacker, Game::weaponParms* wpParms, float player_meleeRange, float player_meleeWidth, float player_meleeHeight);
 	};
 }

--- a/src/Components/Modules/Melee.hpp
+++ b/src/Components/Modules/Melee.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace Components
+{
+	class Melee : public Component
+	{
+	public:
+		Melee();
+
+		static void Weapon_Melee(Game::gentity_s* attacker, Game::weaponParms* wpParms, float player_meleeRange, float player_meleeWidth, float player_meleeHeight, int gameTime);
+		static void FireWeaponMelee(Game::gentity_s* ent, int gameTime);
+	};
+}

--- a/src/Components/Modules/QuickPatch.cpp
+++ b/src/Components/Modules/QuickPatch.cpp
@@ -53,62 +53,6 @@ namespace Components
 		}
 	}
 
-	Game::dvar_t* QuickPatch::g_antilag;
-	__declspec(naked) void QuickPatch::ClientEventsFireWeapon_Stub()
-	{
-		__asm
-		{
-			// check g_antilag dvar value
-			mov eax, g_antilag;
-			cmp byte ptr [eax + 16], 1;
-
-			// do antilag if 1
-			je fireWeapon
-
-			// do not do antilag if 0
-			mov eax, 0x1A83554 // level.time
-			mov ecx, [eax]
-
-		fireWeapon:
-			push edx
-			push ecx
-			push edi
-			mov eax, 0x4A4D50 // FireWeapon
-			call eax
-			add esp, 0Ch
-			pop edi
-			pop ecx
-			retn
-		}
-	}
-
-	__declspec(naked) void QuickPatch::ClientEventsFireWeaponMelee_Stub()
-	{
-		__asm
-		{
-			// check g_antilag dvar value
-			mov eax, g_antilag;
-			cmp byte ptr [eax + 16], 1;
-
-			// do antilag if 1
-			je fireWeaponMelee
-
-			// do not do antilag if 0
-			mov eax, 0x1A83554 // level.time
-			mov edx, [eax]
-
-		fireWeaponMelee:
-			push edx
-			push edi
-			mov eax, 0x4F2470 // FireWeaponMelee
-			call eax
-			add esp, 8
-			pop edi
-			pop ecx
-			retn
-		}
-	}
-
 	Game::dvar_t* QuickPatch::Dvar_RegisterAspectRatioDvar(const char* dvarName, const char** /*valueList*/, int defaultIndex, unsigned __int16 flags, const char* description)
 	{
 		static const char* r_aspectRatioEnum[] =
@@ -307,10 +251,6 @@ namespace Components
 
 		// Intermission time dvar
 		Game::Dvar_RegisterFloat("scr_intermissionTime", 10, 0, 120, Game::DVAR_NONE, "Time in seconds before match server loads the next map");
-
-		g_antilag = Game::Dvar_RegisterBool("g_antilag", true, Game::DVAR_CODINFO, "Perform antilag");
-		Utils::Hook(0x5D6D56, QuickPatch::ClientEventsFireWeapon_Stub, HOOK_JUMP).install()->quick();
-		Utils::Hook(0x5D6D6A, QuickPatch::ClientEventsFireWeaponMelee_Stub, HOOK_JUMP).install()->quick();
 
 		// Add ultrawide support
 		Utils::Hook(0x51B13B, QuickPatch::Dvar_RegisterAspectRatioDvar, HOOK_CALL).install()->quick();

--- a/src/Components/Modules/QuickPatch.hpp
+++ b/src/Components/Modules/QuickPatch.hpp
@@ -17,10 +17,6 @@ namespace Components
 		static void SetAspectRatio_Stub();
 		static void SetAspectRatio();
 
-		static Game::dvar_t* g_antilag;
-		static void ClientEventsFireWeapon_Stub();
-		static void ClientEventsFireWeaponMelee_Stub();
-
 		static BOOL IsDynClassname_Stub(const char* classname);
 
 		static void CL_KeyEvent_OnEscape();

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -239,7 +239,7 @@ namespace Game
 	SV_LinkEntity_t SV_LinkEntity = SV_LinkEntity_t(0x4E0880);
 	OnSameTeam_t OnSameTeam = OnSameTeam_t(0x4BEB80);
 	Melee_Trace_t Melee_Trace = Melee_Trace_t(0x5FCCF0);
-	G_RunItem_t G_RunItem = G_RunItem_t(0x43B9D0);
+	G_RunItem_t G_GeneralLink = G_RunItem_t(0x43B9D0);
 	G_RunThink_t G_RunThink = G_RunThink_t(0x43EC40);
 
 	G_RunMissileInternal_t G_RunMissileInternal = G_RunMissileInternal_t(0x5E8BE0);

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -233,6 +233,12 @@ namespace Game
 	Weapon_RocketLauncher_Fire_t Weapon_RocketLauncher_Fire = Weapon_RocketLauncher_Fire_t(0x424680);
 	Bullet_Fire_t Bullet_Fire = Bullet_Fire_t(0x4402C0);
 
+	FireWeapon_t FireWeapon = FireWeapon_t(0x4A4D50);
+	FireWeaponMelee_t FireWeaponMelee = FireWeaponMelee_t(0x4F2470);
+	GetClientPositionAtTime_t GetClientPositionAtTime = GetClientPositionAtTime_t(0x455960);
+	SV_LinkEntity_t SV_LinkEntity = SV_LinkEntity_t(0x4E0880);
+	OnSameTeam_t OnSameTeam = OnSameTeam_t(0x4BEB80);
+
 	IN_RecenterMouse_t IN_RecenterMouse = IN_RecenterMouse_t(0x463D80);
 
 	IN_MouseMove_t IN_MouseMove = IN_MouseMove_t(0x64C490);

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -238,6 +238,24 @@ namespace Game
 	GetClientPositionAtTime_t GetClientPositionAtTime = GetClientPositionAtTime_t(0x455960);
 	SV_LinkEntity_t SV_LinkEntity = SV_LinkEntity_t(0x4E0880);
 	OnSameTeam_t OnSameTeam = OnSameTeam_t(0x4BEB80);
+	Melee_Trace_t Melee_Trace = Melee_Trace_t(0x5FCCF0);
+	G_RunItem_t G_RunItem = G_RunItem_t(0x43B9D0);
+	G_RunThink_t G_RunThink = G_RunThink_t(0x43EC40);
+
+	G_RunMissileInternal_t G_RunMissileInternal = G_RunMissileInternal_t(0x5E8BE0);
+
+	Bullet_GetMethodOfDeath_t Bullet_GetMethodOfDeath = Bullet_GetMethodOfDeath_t(0x4A0420);
+	Bullet_Endpos_t Bullet_Endpos = Bullet_Endpos_t(0x4D1A50);
+	BG_WeaponBulletFire_ShouldPenetrate_t BG_WeaponBulletFire_ShouldPenetrate = BG_WeaponBulletFire_ShouldPenetrate_t(0x4B5380);
+	BG_WeaponBulletFire_ShouldSpread_t BG_WeaponBulletFire_ShouldSpread = BG_WeaponBulletFire_ShouldSpread_t(0x4D7D90);
+	Bullet_PenetrationTrace_t Bullet_PenetrationTrace = Bullet_PenetrationTrace_t(0x5D60D0);
+	Bullet_SpreadTrace_t Bullet_SpreadTrace = Bullet_SpreadTrace_t(0x5D5F50);
+	Bullet_ShotgunSpread_t Bullet_ShotgunSpread = Bullet_ShotgunSpread_t(0x5D6860);
+
+	Trace_GetEntityHitId_t Trace_GetEntityHitId = Trace_GetEntityHitId_t(0x501F90);
+	G_ShieldNotifyAndDamage_t G_ShieldNotifyAndDamage = G_ShieldNotifyAndDamage_t(0x4BFA10);
+	G_Damage_t G_Damage = G_Damage_t(0x418600);
+	Melee_Trace_Internal_t Melee_Trace_Internal = Melee_Trace_Internal_t(0x5FC8A0);
 
 	IN_RecenterMouse_t IN_RecenterMouse = IN_RecenterMouse_t(0x463D80);
 

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -248,8 +248,8 @@ namespace Game
 	Bullet_Endpos_t Bullet_Endpos = Bullet_Endpos_t(0x4D1A50);
 	BG_WeaponBulletFire_ShouldPenetrate_t BG_WeaponBulletFire_ShouldPenetrate = BG_WeaponBulletFire_ShouldPenetrate_t(0x4B5380);
 	BG_WeaponBulletFire_ShouldSpread_t BG_WeaponBulletFire_ShouldSpread = BG_WeaponBulletFire_ShouldSpread_t(0x4D7D90);
-	Bullet_PenetrationTrace_t Bullet_PenetrationTrace = Bullet_PenetrationTrace_t(0x5D60D0);
-	Bullet_SpreadTrace_t Bullet_SpreadTrace = Bullet_SpreadTrace_t(0x5D5F50);
+	Bullet_PenetrationTrace_t Bullet_FirePenetrate = Bullet_PenetrationTrace_t(0x5D60D0);
+	Bullet_SpreadTrace_t Bullet_FireExtended = Bullet_SpreadTrace_t(0x5D5F50);
 	Bullet_ShotgunSpread_t Bullet_ShotgunSpread = Bullet_ShotgunSpread_t(0x5D6860);
 
 	Trace_GetEntityHitId_t Trace_GetEntityHitId = Trace_GetEntityHitId_t(0x501F90);

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -315,7 +315,7 @@ namespace Game
 	extern Melee_Trace_t Melee_Trace;
 
 	typedef void(*G_RunItem_t)(gentity_s* item);
-	extern G_RunItem_t G_RunItem;
+	extern G_RunItem_t G_GeneralLink;
 
 	typedef void(*G_RunThink_t)(gentity_s* thinkable);
 	extern G_RunThink_t G_RunThink;

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -313,10 +313,13 @@ namespace Game
 
 	typedef void (*FireWeapon_t)(Game::gentity_s* ent, int gameTime, int a3);
 	extern FireWeapon_t FireWeapon;
+
 	typedef void (*FireWeaponMelee_t)(Game::gentity_s* ent, int gameTime);
 	extern FireWeaponMelee_t FireWeaponMelee;
+
 	typedef bool (*GetClientPositionAtTime_t)(int targetTime, vec3_t* clientsOrigins, vec3_t* clientsAngles, bool* clientsMoved);
 	extern GetClientPositionAtTime_t GetClientPositionAtTime;
+
 	typedef void (*SV_LinkEntity_t)(Game::gentity_s* ent);
 	extern SV_LinkEntity_t SV_LinkEntity;
 

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -308,6 +308,18 @@ namespace Game
 	typedef void(*NET_DeferPacketToClient_t)(netadr_t*, msg_t*);
 	extern NET_DeferPacketToClient_t NET_DeferPacketToClient;
 
+	typedef bool(*OnSameTeam_t)(gentity_s* a1, gentity_s* a2);
+	extern OnSameTeam_t OnSameTeam;
+
+	typedef void (*FireWeapon_t)(Game::gentity_s* ent, int gameTime, int a3);
+	extern FireWeapon_t FireWeapon;
+	typedef void (*FireWeaponMelee_t)(Game::gentity_s* ent, int gameTime);
+	extern FireWeaponMelee_t FireWeaponMelee;
+	typedef bool (*GetClientPositionAtTime_t)(int targetTime, vec3_t* clientsOrigins, vec3_t* clientsAngles, bool* clientsMoved);
+	extern GetClientPositionAtTime_t GetClientPositionAtTime;
+	typedef void (*SV_LinkEntity_t)(Game::gentity_s* ent);
+	extern SV_LinkEntity_t SV_LinkEntity;
+
 	typedef const char* (*NET_ErrorString_t)();
 	extern NET_ErrorString_t NET_ErrorString;
 

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -341,20 +341,20 @@ namespace Game
 	extern BG_WeaponBulletFire_ShouldSpread_t BG_WeaponBulletFire_ShouldSpread;
 
 	typedef void(*Bullet_PenetrationTrace_t)(uint32_t* randomSeed,
-		BulletContext_t* bullet,
-		trace_t* tr,
+		BulletFireParams* bullet,
+		BulletTraceResults* tr,
 		unsigned int weaponIndex,
 		gentity_s* attacker,
 		int gameTime);
-	extern Bullet_PenetrationTrace_t Bullet_PenetrationTrace;
+	extern Bullet_PenetrationTrace_t Bullet_FirePenetrate;
 
 	typedef void(*Bullet_SpreadTrace_t)(int a1,
 		gentity_s* a2,
 		uint32_t* randomSeed,
-		BulletContext_t* bullet,
+		BulletFireParams* bullet,
 		unsigned int weaponIndex,
 		int gameTime);
-	extern Bullet_SpreadTrace_t Bullet_SpreadTrace;
+	extern Bullet_SpreadTrace_t Bullet_FireExtended;
 
 	typedef void(*Bullet_ShotgunSpread_t)(gentity_s*/*@<eax>*/ attacker, float range, float spread, weaponParms* wpParms, gentity_s* weaponEnt);
 	extern Bullet_ShotgunSpread_t Bullet_ShotgunSpread;

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -30,10 +30,10 @@ namespace Game
 	typedef void(*CG_DrawDisconnect_t)(int localClientNum);
 	extern CG_DrawDisconnect_t CG_DrawDisconnect;
 
-	typedef void(*CG_LocationalTrace_t)(trace_t *results, const float *start, const float *end, int passEntityNum, int contentMask);
+	typedef void(*CG_LocationalTrace_t)(trace_t* results, const float* start, const float* end, int passEntityNum, int contentMask);
 	extern  CG_LocationalTrace_t CG_LocationalTrace;
 
-	typedef void(*CG_WorldTrace_t)(trace_t *results, const float *start, const float *end, Bounds *bounds, int brushmask);
+	typedef void(*CG_WorldTrace_t)(trace_t* results, const float* start, const float* end, Bounds* bounds, int brushmask);
 	extern  CG_WorldTrace_t CG_WorldTrace;
 
 	typedef void(*CG_NextWeapon_f_t)();
@@ -45,7 +45,7 @@ namespace Game
 	typedef void(*CG_PlayBoltedEffect_t)(int localClientNum, FxEffectDef* fxDef, int dobjHandle, unsigned int boneName);
 	extern CG_PlayBoltedEffect_t CG_PlayBoltedEffect;
 
-	typedef const DObj*(*CG_GetBoneIndex_t)(int localClientNum, unsigned int boneName, char* boneIndex);
+	typedef const DObj* (*CG_GetBoneIndex_t)(int localClientNum, unsigned int boneName, char* boneIndex);
 	extern CG_GetBoneIndex_t CG_GetBoneIndex;
 
 	typedef void(*CG_ScoresDown_f_t)();
@@ -60,7 +60,7 @@ namespace Game
 	typedef void(*CG_ScrollScoreboardDown_t)(cg_s* cgameGlob);
 	extern CG_ScrollScoreboardDown_t CG_ScrollScoreboardDown;
 
-	typedef const char*(*CG_GetTeamName_t)(team_t team);
+	typedef const char* (*CG_GetTeamName_t)(team_t team);
 	extern CG_GetTeamName_t CG_GetTeamName;
 
 	typedef void(*CG_SetupWeaponConfigString_t)(int localClientNum, unsigned int weapIndex);
@@ -78,7 +78,7 @@ namespace Game
 	typedef void(*Cmd_ForEach_t)(void(*callback)(const char* str));
 	extern Cmd_ForEach_t Cmd_ForEach;
 
-	typedef char*(*Con_DrawMiniConsole_t)(int localClientNum, int xPos, int yPos, float alpha);
+	typedef char* (*Con_DrawMiniConsole_t)(int localClientNum, int xPos, int yPos, float alpha);
 	extern Con_DrawMiniConsole_t Con_DrawMiniConsole;
 
 	typedef void (*Con_DrawSolidConsole_t)();
@@ -90,7 +90,7 @@ namespace Game
 	typedef bool(*Con_IsDvarCommand_t)(const char* cmd);
 	extern Con_IsDvarCommand_t Con_IsDvarCommand;
 
-	typedef bool(*Encode_Init_t)(const char* );
+	typedef bool(*Encode_Init_t)(const char*);
 	extern Encode_Init_t Encode_Init;
 
 	typedef void(*Field_Clear_t)(void* field);
@@ -105,7 +105,7 @@ namespace Game
 	typedef void(*Svcmd_EntityList_f_t)();
 	extern Svcmd_EntityList_f_t Svcmd_EntityList_f;
 
-	typedef int(*Reader_t)(char const*, int *);
+	typedef int(*Reader_t)(char const*, int*);
 
 	typedef bool(*Image_LoadFromFileWithReader_t)(GfxImage* image, Reader_t reader);
 	extern Image_LoadFromFileWithReader_t Image_LoadFromFileWithReader;
@@ -113,7 +113,7 @@ namespace Game
 	typedef void(*Image_Release_t)(GfxImage* image);
 	extern Image_Release_t Image_Release;
 
-	typedef char*(*Info_ValueForKey_t)(const char* s, const char* key);
+	typedef char* (*Info_ValueForKey_t)(const char* s, const char* key);
 	extern Info_ValueForKey_t Info_ValueForKey;
 
 	typedef int(*Info_Validate_t)(const char* s);
@@ -194,7 +194,7 @@ namespace Game
 	typedef int(*Menus_OpenByName_t)(UiContext* dc, const char* p);
 	extern Menus_OpenByName_t Menus_OpenByName;
 
-	typedef menuDef_t*(*Menus_FindByName_t)(UiContext* dc, const char* name);
+	typedef menuDef_t* (*Menus_FindByName_t)(UiContext* dc, const char* name);
 	extern Menus_FindByName_t Menus_FindByName;
 
 	typedef bool(*Menu_IsVisible_t)(UiContext* dc, menuDef_t* menu);
@@ -206,7 +206,7 @@ namespace Game
 	typedef void(*Menu_HandleKey_t)(UiContext* ctx, menuDef_t* menu, Game::keyNum_t key, int down);
 	extern Menu_HandleKey_t Menu_HandleKey;
 
-	typedef menuDef_t*(*Menu_GetFocused_t)(UiContext* ctx);
+	typedef menuDef_t* (*Menu_GetFocused_t)(UiContext* ctx);
 	extern Menu_GetFocused_t Menu_GetFocused;
 
 	typedef void(*Menu_Setup_t)(UiContext* dc);
@@ -215,7 +215,7 @@ namespace Game
 	typedef bool(*UI_KeyEvent_t)(int clientNum, int key, int down);
 	extern UI_KeyEvent_t UI_KeyEvent;
 
-	typedef const char*(*UI_SafeTranslateString_t)(const char* reference);
+	typedef const char* (*UI_SafeTranslateString_t)(const char* reference);
 	extern UI_SafeTranslateString_t UI_SafeTranslateString;
 
 	typedef void(*UI_ReplaceConversions_t)(const char* sourceString, ConversionArguments* arguments, char* outputString, size_t outputStringSize);
@@ -224,7 +224,7 @@ namespace Game
 	typedef int(*UI_ParseInfos_t)(const char* buf, int max, char** infos);
 	extern UI_ParseInfos_t UI_ParseInfos;
 
-	typedef const char*(*UI_GetMapDisplayName_t)(const char* pszMap);
+	typedef const char* (*UI_GetMapDisplayName_t)(const char* pszMap);
 	extern UI_GetMapDisplayName_t UI_GetMapDisplayName;
 
 	typedef const char* (*UI_GetGameTypeDisplayName_t)(const char* pszGameType);
@@ -254,25 +254,25 @@ namespace Game
 	typedef __int64(*MSG_ReadInt64_t)(msg_t* msg);
 	extern MSG_ReadInt64_t MSG_ReadInt64;
 
-	typedef char*(*MSG_ReadBigString_t)(msg_t* msg);
+	typedef char* (*MSG_ReadBigString_t)(msg_t* msg);
 	extern MSG_ReadBigString_t MSG_ReadBigString;
 
-	typedef char*(*MSG_ReadStringLine_t)(msg_t *msg, char *string, unsigned int maxChars);
+	typedef char* (*MSG_ReadStringLine_t)(msg_t* msg, char* string, unsigned int maxChars);
 	extern MSG_ReadStringLine_t MSG_ReadStringLine;
 
 	typedef void(*MSG_WriteByte_t)(msg_t* msg, int c);
 	extern MSG_WriteByte_t MSG_WriteByte;
 
-	typedef void(*MSG_WriteData_t)(msg_t *buf, const void *data, int length);
+	typedef void(*MSG_WriteData_t)(msg_t* buf, const void* data, int length);
 	extern MSG_WriteData_t MSG_WriteData;
 
-	typedef void(*MSG_WriteLong_t)(msg_t *msg, int c);
+	typedef void(*MSG_WriteLong_t)(msg_t* msg, int c);
 	extern MSG_WriteLong_t MSG_WriteLong;
 
 	typedef void(*MSG_WriteShort_t)(msg_t* msg, int s);
 	extern MSG_WriteShort_t MSG_WriteShort;
 
-	typedef void(*MSG_WriteString_t)(msg_t* msg, const char *str);
+	typedef void(*MSG_WriteString_t)(msg_t* msg, const char* str);
 	extern MSG_WriteString_t MSG_WriteString;
 
 	typedef void(*MSG_Discard_t)(msg_t* msg);
@@ -293,10 +293,10 @@ namespace Game
 	typedef void(*Huff_offsetReceive_t)(nodetype* node, int* ch, const unsigned char* fin, int* offset);
 	extern Huff_offsetReceive_t Huff_offsetReceive;
 
-	typedef void(*NetadrToSockadr_t)(netadr_t *a, sockaddr *s);
+	typedef void(*NetadrToSockadr_t)(netadr_t* a, sockaddr* s);
 	extern NetadrToSockadr_t NetadrToSockadr;
 
-	typedef const char*(*NET_AdrToString_t)(netadr_t adr);
+	typedef const char* (*NET_AdrToString_t)(netadr_t adr);
 	extern NET_AdrToString_t NET_AdrToString;
 
 	typedef bool(*NET_CompareAdr_t)(netadr_t a, netadr_t b);
@@ -310,6 +310,66 @@ namespace Game
 
 	typedef bool(*OnSameTeam_t)(gentity_s* a1, gentity_s* a2);
 	extern OnSameTeam_t OnSameTeam;
+
+	typedef gentity_s* (*Melee_Trace_t)(gentity_s* attacker, weaponParms* wp_parms, float meleeRange, float meleeWidth, float meleeHeight);
+	extern Melee_Trace_t Melee_Trace;
+
+	typedef void(*G_RunItem_t)(gentity_s* item);
+	extern G_RunItem_t G_RunItem;
+
+	typedef void(*G_RunThink_t)(gentity_s* thinkable);
+	extern G_RunThink_t G_RunThink;
+
+	typedef void(*G_RunMissileInternal_t)(gentity_s* missile);
+	extern G_RunMissileInternal_t G_RunMissileInternal;
+
+	typedef int(*Bullet_GetMethodOfDeath_t)(uint32_t* perks, const WeaponDef* wpDef);
+	extern Bullet_GetMethodOfDeath_t Bullet_GetMethodOfDeath;
+
+	typedef void(*Bullet_Endpos_t)(uint32_t* randomSeed,
+		float spread,
+		float* endPos,
+		float* muzzleDir,
+		weaponParms* forward,
+		float range);
+	extern Bullet_Endpos_t Bullet_Endpos;
+
+	typedef bool(*BG_WeaponBulletFire_ShouldPenetrate_t)(uint32_t* perks, const WeaponDef* wpDef);
+	extern BG_WeaponBulletFire_ShouldPenetrate_t BG_WeaponBulletFire_ShouldPenetrate;
+
+	typedef bool(*BG_WeaponBulletFire_ShouldSpread_t)(uint32_t* perks, const WeaponDef* wpDef);
+	extern BG_WeaponBulletFire_ShouldSpread_t BG_WeaponBulletFire_ShouldSpread;
+
+	typedef void(*Bullet_PenetrationTrace_t)(uint32_t* randomSeed,
+		BulletContext_t* bullet,
+		trace_t* tr,
+		unsigned int weaponIndex,
+		gentity_s* attacker,
+		int gameTime);
+	extern Bullet_PenetrationTrace_t Bullet_PenetrationTrace;
+
+	typedef void(*Bullet_SpreadTrace_t)(int a1,
+		gentity_s* a2,
+		uint32_t* randomSeed,
+		BulletContext_t* bullet,
+		unsigned int weaponIndex,
+		int gameTime);
+	extern Bullet_SpreadTrace_t Bullet_SpreadTrace;
+
+	typedef void(*Bullet_ShotgunSpread_t)(gentity_s*/*@<eax>*/ attacker, float range, float spread, weaponParms* wpParms, gentity_s* weaponEnt);
+	extern Bullet_ShotgunSpread_t Bullet_ShotgunSpread;
+
+	typedef uint16_t(*Trace_GetEntityHitId_t)(trace_t* a1);
+	extern Trace_GetEntityHitId_t Trace_GetEntityHitId;
+
+	typedef void(*G_ShieldNotifyAndDamage_t)(gentity_s* hit_entity, gentity_s* attacker, gentity_s* overrideAttackerIdk, float* endPoint, float* hitPoint, int, int, int, int, int);
+	extern G_ShieldNotifyAndDamage_t G_ShieldNotifyAndDamage;
+
+	typedef void(*G_Damage_t)(gentity_s*, gentity_s*, gentity_s*, float*, float*, int, int, unsigned int, int, int, int, int, int);
+	extern G_Damage_t G_Damage;
+
+	typedef bool(*Melee_Trace_Internal_t)(gentity_s* a1, weaponParms* a2, int a3, float a4, float a5, float a6, trace_t* tr, float* a8);
+	extern Melee_Trace_Internal_t Melee_Trace_Internal;
 
 	typedef void (*FireWeapon_t)(Game::gentity_s* ent, int gameTime, int a3);
 	extern FireWeapon_t FireWeapon;
@@ -344,7 +404,7 @@ namespace Game
 	typedef int(*NET_OutOfBandVoiceData_t)(netsrc_t sock, netadr_t adr, unsigned char* format, int len, bool voiceData);
 	extern NET_OutOfBandVoiceData_t NET_OutOfBandVoiceData;
 
-	typedef void(*Live_MPAcceptInvite_t)(_XSESSION_INFO *hostInfo, int controllerIndex, bool fromGameInvite);
+	typedef void(*Live_MPAcceptInvite_t)(_XSESSION_INFO* hostInfo, int controllerIndex, bool fromGameInvite);
 	extern Live_MPAcceptInvite_t Live_MPAcceptInvite;
 
 	typedef int(*Live_GetMapIndex_t)(const char* mapname);
@@ -356,7 +416,7 @@ namespace Game
 	typedef int(*Live_GetXp_t)(int controllerIndex);
 	extern Live_GetXp_t Live_GetXp;
 
-	typedef const char*(*Live_GetLocalClientName_t)(int controllerIndex);
+	typedef const char* (*Live_GetLocalClientName_t)(int controllerIndex);
 	extern Live_GetLocalClientName_t Live_GetLocalClientName;
 
 	typedef bool(*Live_IsSystemUiActive_t)();
@@ -368,7 +428,7 @@ namespace Game
 	typedef void(*LiveStorage_SetStat_t)(int controllerIndex, int index, int value);
 	extern LiveStorage_SetStat_t LiveStorage_SetStat;
 
-	typedef char*(*Scr_AddSourceBuffer_t)(const char* filename, const char* extFilename, const char* codePos, bool archive);
+	typedef char* (*Scr_AddSourceBuffer_t)(const char* filename, const char* extFilename, const char* codePos, bool archive);
 	extern Scr_AddSourceBuffer_t Scr_AddSourceBuffer;
 
 	typedef int(*Party_GetMaxPlayers_t)(PartyData* party);
@@ -377,10 +437,10 @@ namespace Game
 	typedef int(*PartyHost_CountMembers_t)(PartyData* party);
 	extern PartyHost_CountMembers_t PartyHost_CountMembers;
 
-	typedef netadr_t *(*PartyHost_GetMemberAddressBySlot_t)(int unk, void *party, const int slot);
+	typedef netadr_t* (*PartyHost_GetMemberAddressBySlot_t)(int unk, void* party, const int slot);
 	extern PartyHost_GetMemberAddressBySlot_t PartyHost_GetMemberAddressBySlot;
 
-	typedef const char *(*PartyHost_GetMemberName_t)(PartyData* party, const int clientNum);
+	typedef const char* (*PartyHost_GetMemberName_t)(PartyData* party, const int clientNum);
 	extern PartyHost_GetMemberName_t PartyHost_GetMemberName;
 
 	typedef int(*Party_InParty_t)(PartyData* party);
@@ -398,16 +458,16 @@ namespace Game
 	typedef void (*PM_Weapon_t)(Game::pmove_s* pm, Game::pml_t* pml);
 	extern PM_Weapon_t PM_Weapon;
 
-	typedef Font_s*(*R_RegisterFont_t)(const char* asset, int safe);
+	typedef Font_s* (*R_RegisterFont_t)(const char* asset, int safe);
 	extern R_RegisterFont_t R_RegisterFont;
 
-	typedef void(*R_AddCmdDrawText_t)(const char *text, int maxChars, Font_s *font, float x, float y, float xScale, float yScale, float rotation, const float *color, int style);
+	typedef void(*R_AddCmdDrawText_t)(const char* text, int maxChars, Font_s* font, float x, float y, float xScale, float yScale, float rotation, const float* color, int style);
 	extern R_AddCmdDrawText_t R_AddCmdDrawText;
 
-	typedef void(*R_AddCmdDrawStretchPic_t)(float x, float y, float w, float h, float xScale, float yScale, float xay, float yay, const float *color, Game::Material* material);
+	typedef void(*R_AddCmdDrawStretchPic_t)(float x, float y, float w, float h, float xScale, float yScale, float xay, float yay, const float* color, Game::Material* material);
 	extern R_AddCmdDrawStretchPic_t R_AddCmdDrawStretchPic;
 
-	typedef void*(*R_AllocStaticIndexBuffer_t)(IDirect3DIndexBuffer9** store, int length);
+	typedef void* (*R_AllocStaticIndexBuffer_t)(IDirect3DIndexBuffer9** store, int length);
 	extern R_AllocStaticIndexBuffer_t R_AllocStaticIndexBuffer;
 
 	typedef bool(*R_Cinematic_StartPlayback_Now_t)();
@@ -425,13 +485,13 @@ namespace Game
 	typedef void(*R_FlushSun_t)();
 	extern R_FlushSun_t R_FlushSun;
 
-	typedef GfxWorld*(*R_SortWorldSurfaces_t)();
+	typedef GfxWorld* (*R_SortWorldSurfaces_t)();
 	extern R_SortWorldSurfaces_t R_SortWorldSurfaces;
 
 	typedef void* (*GetMemory_t)(unsigned int size);
 	extern GetMemory_t GetMemory;
 
-	typedef void*(*GetClearedMemory_t)(unsigned int size);
+	typedef void* (*GetClearedMemory_t)(unsigned int size);
 	extern GetClearedMemory_t GetClearedMemory;
 
 	typedef void(*PS_CreatePunctuationTable_t)(script_s* script, punctuation_s* punctuations);
@@ -440,10 +500,10 @@ namespace Game
 	typedef void(*free_expression_t)(Statement_s* statement);
 	extern free_expression_t free_expression;
 
-	typedef char*(*SE_Load_t)(const char* psFileName, bool forceEnglish);
+	typedef char* (*SE_Load_t)(const char* psFileName, bool forceEnglish);
 	extern SE_Load_t SE_Load;
 
-	typedef char*(*SEH_StringEd_GetString_t)(const char* string);
+	typedef char* (*SEH_StringEd_GetString_t)(const char* string);
 	extern SEH_StringEd_GetString_t SEH_StringEd_GetString;
 
 	typedef unsigned int(*SEH_ReadCharFromString_t)(const char** text, int* isTrailingPunctuation);
@@ -458,7 +518,7 @@ namespace Game
 	typedef void(*SND_InitDriver_t)();
 	extern SND_InitDriver_t SND_InitDriver;
 
-	typedef void(*SockadrToNetadr_t)(sockaddr *s, netadr_t *a);
+	typedef void(*SockadrToNetadr_t)(sockaddr* s, netadr_t* a);
 	extern SockadrToNetadr_t SockadrToNetadr;
 
 	typedef void(*Steam_JoinLobby_t)(SteamID, char);
@@ -473,10 +533,10 @@ namespace Game
 	typedef uiMenuCommand_t(*UI_GetActiveMenu_t)(int localClientNum);
 	extern UI_GetActiveMenu_t UI_GetActiveMenu;
 
-	typedef char*(*UI_CheckStringTranslation_t)(char*, char*);
+	typedef char* (*UI_CheckStringTranslation_t)(char*, char*);
 	extern UI_CheckStringTranslation_t UI_CheckStringTranslation;
 
-	typedef MenuList*(*UI_LoadMenus_t)(const char* menuFile, int imageTrack);
+	typedef MenuList* (*UI_LoadMenus_t)(const char* menuFile, int imageTrack);
 	extern UI_LoadMenus_t UI_LoadMenus;
 
 	typedef void(*UI_UpdateArenas_t)();
@@ -488,7 +548,7 @@ namespace Game
 	typedef void(*UI_DrawHandlePic_t)(ScreenPlacement* scrPlace, float x, float y, float w, float h, int horzAlign, int vertAlign, const float* color, Material* material);
 	extern UI_DrawHandlePic_t UI_DrawHandlePic;
 
-	typedef ScreenPlacement*(*ScrPlace_GetActivePlacement_t)(int localClientNum);
+	typedef ScreenPlacement* (*ScrPlace_GetActivePlacement_t)(int localClientNum);
 	extern ScrPlace_GetActivePlacement_t ScrPlace_GetActivePlacement;
 
 	typedef int(*UI_TextWidth_t)(const char* text, int maxChars, Font_s* font, float scale);
@@ -500,13 +560,13 @@ namespace Game
 	typedef void(*UI_DrawText_t)(const ScreenPlacement* scrPlace, const char* text, int maxChars, Font_s* font, float x, float y, int horzAlign, int vertAlign, float scale, const float* color, int style);
 	extern UI_DrawText_t UI_DrawText;
 
-	typedef Font_s*(*UI_GetFontHandle_t)(ScreenPlacement* scrPlace, int fontEnum, float scale);
+	typedef Font_s* (*UI_GetFontHandle_t)(ScreenPlacement* scrPlace, int fontEnum, float scale);
 	extern UI_GetFontHandle_t UI_GetFontHandle;
 
 	typedef void(*ScrPlace_ApplyRect_t)(const ScreenPlacement* scrPlace, float* x, float* y, float* w, float* h, int horzAlign, int vertAlign);
 	extern ScrPlace_ApplyRect_t ScrPlace_ApplyRect;
 
-	typedef const char*(*Win_GetLanguage_t)();
+	typedef const char* (*Win_GetLanguage_t)();
 	extern Win_GetLanguage_t Win_GetLanguage;
 
 	typedef void(*Vec3UnpackUnitVec_t)(PackedUnitVec, vec3_t*);
@@ -551,7 +611,7 @@ namespace Game
 	typedef void(*AimAssist_ApplyAutoMelee_t)(const AimInput* input, AimOutput* output);
 	extern AimAssist_ApplyAutoMelee_t AimAssist_ApplyAutoMelee;
 
-	typedef gentity_s*(*Weapon_RocketLauncher_Fire_t)(gentity_s* ent, unsigned int weaponIndex, float spread, weaponParms* wp, const float* gunVel, lockonFireParms* lockParms, bool magicBullet);
+	typedef gentity_s* (*Weapon_RocketLauncher_Fire_t)(gentity_s* ent, unsigned int weaponIndex, float spread, weaponParms* wp, const float* gunVel, lockonFireParms* lockParms, bool magicBullet);
 	extern Weapon_RocketLauncher_Fire_t Weapon_RocketLauncher_Fire;
 
 	typedef int(*Bullet_Fire_t)(gentity_s* attacker, float spread, weaponParms* wp, gentity_s* weaponEnt, PlayerHandIndex hand, int gameTime);
@@ -596,7 +656,7 @@ namespace Game
 	typedef void(*I_strncpyz_t)(char* dest, const char* src, int destsize);
 	extern I_strncpyz_t I_strncpyz;
 
-	typedef char*(*I_CleanStr_t)(char* string);
+	typedef char* (*I_CleanStr_t)(char* string);
 	extern I_CleanStr_t I_CleanStr;
 
 	typedef bool(*I_isdigit_t)(int c);
@@ -620,13 +680,13 @@ namespace Game
 	typedef void(*LargeLocalReset_t)();
 	extern LargeLocalReset_t LargeLocalReset;
 
-	typedef StructuredDataDef*(*StructuredDataDef_GetAsset_t)(const char* filename, unsigned int maxSize);
+	typedef StructuredDataDef* (*StructuredDataDef_GetAsset_t)(const char* filename, unsigned int maxSize);
 	extern StructuredDataDef_GetAsset_t StructuredDataDef_GetAsset;
 
 	typedef void(*StringTable_GetAsset_FastFile_t)(const char* filename, const StringTable** tablePtr);
 	extern StringTable_GetAsset_FastFile_t StringTable_GetAsset_FastFile;
 
-	typedef const char*(*StringTable_Lookup_t)(const StringTable* table, const int comparisonColumn, const char* value, const int valueColumn);
+	typedef const char* (*StringTable_Lookup_t)(const StringTable* table, const int comparisonColumn, const char* value, const int valueColumn);
 	extern StringTable_Lookup_t StringTable_Lookup;
 
 	typedef int(*StringTable_HashString_t)(const char* string);
@@ -635,19 +695,12 @@ namespace Game
 	typedef int(*StringTable_LookupRowNumForValue_t)(const StringTable* table, int comparisonColumn, const char* value);
 	extern StringTable_LookupRowNumForValue_t StringTable_LookupRowNumForValue;
 
-	typedef const char*(*StringTable_GetColumnValueForRow_t)(const StringTable*, int row, int column);
+	typedef const char* (*StringTable_GetColumnValueForRow_t)(const StringTable*, int row, int column);
 	extern StringTable_GetColumnValueForRow_t StringTable_GetColumnValueForRow;
 
 	typedef void(*longjmp_internal_t)(jmp_buf env, int status);
 	extern longjmp_internal_t longjmp_internal;
 
-	constexpr std::size_t STATIC_MAX_LOCAL_CLIENTS = 1;
-	constexpr std::size_t MAX_LOCAL_CLIENTS = 1;
-	constexpr std::size_t MAX_CLIENTS = 18;
-
-	constexpr auto MAX_CMD_BUFFER = 0x10000;
-	constexpr auto MAX_CMD_LINE = 0x1000;
-	constexpr auto CMD_MAX_NESTING = 8;
 	extern CmdArgs* cmd_args;
 	extern CmdArgs* sv_cmd_args;
 
@@ -831,7 +884,7 @@ namespace Game
 
 	void SortWorldSurfaces(GfxWorld* world);
 	void R_AddDebugLine(float* color, float* v1, float* v2);
-	void R_AddDebugString(float *color, float *pos, float scale, const char *str);
+	void R_AddDebugString(float* color, float* pos, float scale, const char* str);
 	void R_AddDebugBounds(float* color, Bounds* b);
 	void R_AddDebugBounds(float* color, Bounds* b, const float(*quat)[4]);
 

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -19,6 +19,7 @@ namespace Game
 	G_DebugLineWithDuration_t G_DebugLineWithDuration = G_DebugLineWithDuration_t(0x4C3280);
 
 	gentity_s* g_entities = reinterpret_cast<gentity_s*>(0x18835D8);
+	unsigned short* PartName_None = reinterpret_cast<unsigned short*>(0x1AA2E7A); // result of GScr_AllocString("none");
 	bool* g_quitRequested = reinterpret_cast<bool*>(0x649FB61);
 
 	char(*g_cmdlineCopy)[1024] = reinterpret_cast<char(*)[1024]>(0x1AD7AB0);

--- a/src/Game/Game.hpp
+++ b/src/Game/Game.hpp
@@ -58,6 +58,7 @@ namespace Game
 	extern G_DebugLineWithDuration_t G_DebugLineWithDuration;
 
 	extern gentity_s* g_entities;
+	extern unsigned short* PartName_None;
 	extern bool* g_quitRequested;
 
 	extern char(*g_cmdlineCopy)[1024];

--- a/src/Game/Structs.hpp
+++ b/src/Game/Structs.hpp
@@ -7687,8 +7687,6 @@ namespace Game
 		char pad218[92];
 	};
 
-	static_assert(sizeof(gentity_s) == 0x274);
-
 	enum
 	{
 		ENTFIELD_ENTITY = 0x0,
@@ -12169,11 +12167,13 @@ namespace Game
 		WEAP_ANIM_ADS_LASTSHOT = 0x21,
 		WEAP_ANIM_ADS_RECHAMBER = 0x22,
 		WEAP_ANIM_ADS_UP = 0x23,
-	WEAP_ANIM_ADS_DOWN = 0x24,
+		WEAP_ANIM_ADS_DOWN = 0x24,
 
-	NUM_WEAP_ANIMS,
+		NUM_WEAP_ANIMS,
 };
 
-#pragma endregion#ifndef IDA
+#pragma endregion
+
+#ifndef IDA
 }
 #endif

--- a/src/Game/Structs.hpp
+++ b/src/Game/Structs.hpp
@@ -15,6 +15,13 @@
 #ifndef IDA
 namespace Game
 {
+	constexpr std::size_t STATIC_MAX_LOCAL_CLIENTS = 1;
+	constexpr std::size_t MAX_LOCAL_CLIENTS = 1;
+	constexpr std::size_t MAX_CLIENTS = 18;
+
+	constexpr auto MAX_CMD_BUFFER = 0x10000;
+	constexpr auto MAX_CMD_LINE = 0x1000;
+	constexpr auto CMD_MAX_NESTING = 8;
 #endif
 	constexpr std::size_t MAX_GENTITIES = 2048;
 	constexpr std::size_t ENTITYNUM_NONE = MAX_GENTITIES - 1;
@@ -7675,6 +7682,9 @@ namespace Game
 		int useCount;
 		gentity_s* nextFree;
 		int birthTime;
+		char pad210[4];
+		gentity_s** linkedEntity; // used in G_RunMissile, name was guessed
+		char pad218[92];
 	};
 
 	static_assert(sizeof(gentity_s) == 0x274);
@@ -11932,12 +11942,46 @@ namespace Game
 
 	struct AntilagClientStore
 	{
-		float realClientAngles[18][3];
-		float realClientPositions[18][3];
-		bool clientMoved[18];
+		float realClientAngles[MAX_CLIENTS][3];
+		float realClientPositions[MAX_CLIENTS][3];
+		bool clientMoved[MAX_CLIENTS];
+
 		void Reset()
 		{
-			memset(this, 0, sizeof(Game::AntilagClientStore));
+			memset(this, 0, sizeof(AntilagClientStore));
+		}
+	};
+
+	struct BulletTrace_t : Game::trace_t
+	{
+		int unk2C = 0;
+		float vecUnk30[3];
+		bool flag3C = false; 
+		int unk40 = 0;
+	};
+
+	struct BulletContext_t
+	{
+		int weaponIndex = 0;
+		int weaponIndex2 = 0;
+		float unk_flt=1;
+		int bulletMethodOfDeath=0;
+		float muzzleTrace[3];
+		float startPos[3];
+		float endPos[3];
+		float muzzleDir[3];
+
+		void Init(int InitWeaponIndex, weaponParms* wpParms)
+		{
+			this->weaponIndex = InitWeaponIndex;
+			this->weaponIndex2 = InitWeaponIndex;
+			this->unk_flt = 1.0f;
+			this->muzzleTrace[0] = wpParms->muzzleTrace[0];
+			this->muzzleTrace[1] = wpParms->muzzleTrace[1];
+			this->muzzleTrace[2] = wpParms->muzzleTrace[2];
+			this->startPos[0] = wpParms->muzzleTrace[0];
+			this->startPos[1] = wpParms->muzzleTrace[1];
+			this->startPos[2] = wpParms->muzzleTrace[2];
 		}
 	};
 

--- a/src/Game/Structs.hpp
+++ b/src/Game/Structs.hpp
@@ -11956,7 +11956,7 @@ namespace Game
 	{
 		int unk2C = 0;
 		float vecUnk30[3];
-		bool flag3C = false; 
+		bool flag3C = false;
 		int unk40 = 0;
 	};
 
@@ -11964,18 +11964,19 @@ namespace Game
 	{
 		int weaponIndex = 0;
 		int weaponIndex2 = 0;
-		float unk_flt=1;
-		int bulletMethodOfDeath=0;
+		float unkFlt = 1; // most likely is penetationPower?
+		int methodOfDeath = 0;
 		float muzzleTrace[3];
 		float startPos[3];
 		float endPos[3];
 		float muzzleDir[3];
 
+		// this function is inlined in game, game also calls Bullet_GetMethodOfDeath and fills methodOfDeath with its result - we can't due to include errors.
 		void Init(int InitWeaponIndex, weaponParms* wpParms)
 		{
 			this->weaponIndex = InitWeaponIndex;
 			this->weaponIndex2 = InitWeaponIndex;
-			this->unk_flt = 1.0f;
+			this->unkFlt = 1.0f;
 			this->muzzleTrace[0] = wpParms->muzzleTrace[0];
 			this->muzzleTrace[1] = wpParms->muzzleTrace[1];
 			this->muzzleTrace[2] = wpParms->muzzleTrace[2];

--- a/src/Game/Structs.hpp
+++ b/src/Game/Structs.hpp
@@ -11930,6 +11930,17 @@ namespace Game
 		MssStreamReadInfo streamReadInfo[12];
 	};
 
+	struct AntilagClientStore
+	{
+		float realClientAngles[18][3];
+		float realClientPositions[18][3];
+		bool clientMoved[18];
+		void Reset()
+		{
+			memset(this, 0, sizeof(Game::AntilagClientStore));
+		}
+	};
+
 	struct cgMedia_t
 	{
 		Material* whiteMaterial;

--- a/src/Game/Structs.hpp
+++ b/src/Game/Structs.hpp
@@ -11952,39 +11952,44 @@ namespace Game
 		}
 	};
 
-	struct BulletTrace_t : Game::trace_t
+	struct BulletTraceResults
 	{
-		int unk2C = 0;
-		float vecUnk30[3];
-		bool flag3C = false;
+		trace_t trace;
+		gentity_s* hitEnt;
+		float hitPos[3];
+		bool ignoreHitEnt;
 		int unk40 = 0;
 	};
 
-	struct BulletContext_t
+	static_assert(sizeof(BulletTraceResults) == 0x44);
+
+	struct BulletFireParams
 	{
-		int weaponIndex = 0;
-		int weaponIndex2 = 0;
-		float unkFlt = 1; // most likely is penetationPower?
+		int weaponEntIndex = 0;
+		int ignoreEntIndex = 0;
+		float damageMultiplier = 1;
 		int methodOfDeath = 0;
-		float muzzleTrace[3];
-		float startPos[3];
-		float endPos[3];
-		float muzzleDir[3];
+		float start[3];
+		float origStart[3];
+		float end[3];
+		float dir[3];
 
 		// this function is inlined in game, game also calls Bullet_GetMethodOfDeath and fills methodOfDeath with its result - we can't due to include errors.
-		void Init(int InitWeaponIndex, weaponParms* wpParms)
+		void Init(int weaponIndex, weaponParms* wpParms)
 		{
-			this->weaponIndex = InitWeaponIndex;
-			this->weaponIndex2 = InitWeaponIndex;
-			this->unkFlt = 1.0f;
-			this->muzzleTrace[0] = wpParms->muzzleTrace[0];
-			this->muzzleTrace[1] = wpParms->muzzleTrace[1];
-			this->muzzleTrace[2] = wpParms->muzzleTrace[2];
-			this->startPos[0] = wpParms->muzzleTrace[0];
-			this->startPos[1] = wpParms->muzzleTrace[1];
-			this->startPos[2] = wpParms->muzzleTrace[2];
+			this->weaponEntIndex = weaponIndex;
+			this->ignoreEntIndex = weaponIndex;
+			this->damageMultiplier = 1.0f;
+			this->start[0] = wpParms->muzzleTrace[0];
+			this->start[1] = wpParms->muzzleTrace[1];
+			this->start[2] = wpParms->muzzleTrace[2];
+			this->origStart[0] = wpParms->muzzleTrace[0];
+			this->origStart[1] = wpParms->muzzleTrace[1];
+			this->origStart[2] = wpParms->muzzleTrace[2];
 		}
 	};
+
+	static_assert(sizeof(BulletFireParams) == 0x40);
 
 	struct cgMedia_t
 	{
@@ -12164,13 +12169,11 @@ namespace Game
 		WEAP_ANIM_ADS_LASTSHOT = 0x21,
 		WEAP_ANIM_ADS_RECHAMBER = 0x22,
 		WEAP_ANIM_ADS_UP = 0x23,
-		WEAP_ANIM_ADS_DOWN = 0x24,
+	WEAP_ANIM_ADS_DOWN = 0x24,
 
-		NUM_WEAP_ANIMS,
-	};
+	NUM_WEAP_ANIMS,
+};
 
-#pragma endregion
-
-#ifndef IDA
+#pragma endregion#ifndef IDA
 }
 #endif


### PR DESCRIPTION
This PR entirely reworks existing AntiLag, adding optimized mode and debug logs.

AntiLag was rebuilt, it was debugged and some of the issues were fixed with optimized mode.
I also added back IW3 behavior of AntiLag when its disabled adding optimization too.

As bug example - the throwables were calling AntiLag's rewind even after they stuck in/hit the ground, I decided to keep that optimization with **g_antilag 1** since it's obviously a bug.

With optimized mode (**g_antilag 2**) I also disable AntiLag's rewind on teammates. (I did not find scr_FriendlyFire there so its just calling ingame function)

Also I added attacker in arguments of G_AntiLagRewindClientPos which required rebuilding Weapon_Melee, Bullet_Fire and G_RunMissile.

Throwables issue visualization:

https://github.com/user-attachments/assets/d3357ca8-3cd5-46ca-8ecd-ac0e19ba72c8

After fix:

https://github.com/user-attachments/assets/ec720e49-a577-4cc0-be91-3fae7524425d
