### PR TITLE
feat: allow dedis to edit cheat dvars

### DIFF
--- a/src/Components/Modules/Dvar.hpp
+++ b/src/Components/Modules/Dvar.hpp
@@ -57,5 +57,8 @@ namespace Components
 		static void Dvar_RegisterVariant_Stub();
 
 		static const char* Dvar_EnumToString_Stub(const Game::dvar_t* dvar);
+
+		static bool CanEditCheatProtectedDvar(int flags);
+		static void Dvar_IsCheatProtected_Stub();
 	};
 }

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -402,6 +402,8 @@ namespace Game
 
 	huffman_t* msgHuff = reinterpret_cast<huffman_t*>(0x1CB9EC0);
 
+	bool* isCheatOverride = reinterpret_cast<bool*>(0x6444351);
+
 	const char* TableLookup(StringTable* stringtable, int row, int column)
 	{
 		if (!stringtable || !stringtable->values || row >= stringtable->rowCount || column >= stringtable->columnCount) return "";

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -767,6 +767,8 @@ namespace Game
 
 	extern huffman_t* msgHuff;
 
+	extern bool* isCheatOverride;
+
 	constexpr auto MAX_MSGLEN = 0x20000;
 
 	ScreenPlacement* ScrPlace_GetFullPlacement();


### PR DESCRIPTION
**What does this PR do?**

Fixes #61 

**How does this PR change IW4x's behaviour?**

Dedicated servers will be able to edit cheat protected dvars

**Anything else we should know?**

Draft, only testing this patch for now. It may have unintended consequences

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Mention any [related issues](https://github.com/iw4x/iw4x-client/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/iw4x/iw4x-client/blob/master/CODESTYLE.md)
- [X] Minimize the number of commits
