### PR TITLE
fix: restore lobby server / wider crashes

### DIFF
--- a/src/Components/Modules/Dedicated.cpp
+++ b/src/Components/Modules/Dedicated.cpp
@@ -62,7 +62,7 @@ namespace Components
 
 	void Dedicated::PostInitialization()
 	{
-		Command::Execute("exec autoexec.cfg");
+		Command::Execute("exec autoexec.cfg"); // Can be used by mods / server owners at will : Currently shows an error message on a default setup
 		Command::Execute("onlinegame 1");
 		Command::Execute("exec default_xboxlive.cfg");
 		Command::Execute("xblive_rankedmatch 1");

--- a/src/Components/Modules/Party.cpp
+++ b/src/Components/Modules/Party.cpp
@@ -213,9 +213,14 @@ namespace Components
 		Events::OnDvarInit([]
 		{
 			ServerVersion = Dvar::Register<const char*>("sv_version", "", Game::DVAR_SERVERINFO | Game::DVAR_INIT, "Server version");
-			PartyEnable = Dvar::Register<bool>("party_enable", Dedicated::IsEnabled(), Game::DVAR_NONE, "Enable party system");
-			Dvar::Register<bool>("xblive_privatematch", true, Game::DVAR_INIT, "");
 		});
+
+		// Force xblive_privatematch to 1 and prevent it from being modified because IW4x was built around this dvar being always 1
+		Dvar::Register<bool>("xblive_privatematch", true, Game::DVAR_INIT, "private match");
+		// Disable the game's own call to register xblive_privatematch
+		Utils::Hook::Nop(0x420A77, 5);
+
+		PartyEnable = Dvar::Register<bool>("party_enable", Dedicated::IsEnabled(), Game::DVAR_NONE, "Enable party system");
 
 		// Kill the party migrate handler - it's not necessary and has apparently been used in the past for trickery?
 		Utils::Hook(0x46AB70, PartyMigrate_HandlePacket, HOOK_JUMP).install()->quick();
@@ -274,10 +279,8 @@ namespace Components
 		// Force teams, even if not private match
 		Utils::Hook::Set<BYTE>(0x487BB2, 0xEB);
 
-		// Force xblive_privatematch 0 and rename it
-		//Utils::Hook::Set<BYTE>(0x420A6A, 4);
-		Utils::Hook::Set<BYTE>(0x420A6C, 0);
-		Utils::Hook::Set<const char*>(0x420A6E, "xblive_privateserver");
+		// Register xblive_privateserver because it is used by the Info Handlers
+		Dvar::Register<bool>("xblive_privateserver", false, Game::DVAR_NONE, "private server");
 
 		// Remove migration shutdown, it causes crashes and will be destroyed when erroring anyways
 		Utils::Hook::Nop(0x5A8E1C, 12);


### PR DESCRIPTION
**What does this PR do?**

Fixes #174 

**How does this PR change IW4x's behaviour?**

~~Removes a command that executes a cfg that was entirely fabricated by the minds of the OG iw4x's devs and does not exist at all~~ (Reverted: see below) 
<img width="161" alt="image (1)" src="https://github.com/user-attachments/assets/ac1c69bf-5845-4a0d-8ff1-10aec072006e">

**Anything else we should know?**

The dvar mess is now gone, the private match dvar is registered by the live_init function and our custom privateserver function is registered by us because we use it in the info handlers

Add any other context about your changes here.

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Mention any [related issues](https://github.com/iw4x/iw4x-client/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/iw4x/iw4x-client/blob/master/CODESTYLE.md)
- [X] Minimize the number of commits
