### PR TITLE
feat: Add exception address to message and add hyperlink to minidump …

### DIFF
--- a/src/Components/Modules/Exception.hpp
+++ b/src/Components/Modules/Exception.hpp
@@ -17,10 +17,10 @@ namespace Components
 		static LONG WINAPI ExceptionFilter(LPEXCEPTION_POINTERS ExceptionInfo);
 		static __declspec(noreturn) void LongJmp_Internal_Stub(jmp_buf env, int status);
 
-		static std::wstring GetErrorMessage();
+		static std::wstring GetErrorMessage(const std::string& error);
 		static std::string FormatMessageForClipboard(const std::wstring& message);
 
-		static void DisplayErrorMessage(const std::wstring& title, const std::wstring& message);
+		static void DisplayErrorMessage(const std::wstring& title, const std::wstring& message, const std::string& crashDumpFolder);
 		static void CopyMessageToClipboard(const char* error);
 
 		static LPTOP_LEVEL_EXCEPTION_FILTER WINAPI SetUnhandledExceptionFilter_Stub(LPTOP_LEVEL_EXCEPTION_FILTER);


### PR DESCRIPTION
**What does this PR do?**

It adds the exception code and exception address to the clipboard text of the error dialog.  
This gives the support team on the Discord server all the information needed to quickly respond by simply pasting the clipboard text (instead of a screenshot of the dialog or, in most cases, a picture of the monitor).

In addition, a second hyperlink has been added to the footer of the dialog. 
This hyperlink will open the `minidumps` folder of the game installation, making it easier for users to find the crashdumps.

**Anything else we should know?**

The [Win32 API Programming Reference](https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/nf-minidumpapiset-minidumpwritedump?devlangs=cpp&f1url=%3FappId%3DDev17IDEF1%26l%3DEN-US%26k%3Dk(MINIDUMPAPISET%252FMiniDumpWriteDump)%3Bk(MiniDumpWriteDump)%3Bk(DevLang-C%252B%252B)%3Bk(TargetOS-Windows)%26rd%3Dtrue#remarks) recommends writing minidumps from a separate process, or at least a dedicated thread.  
This is something I'm going to look into once I've done some more research on the Windows debugging APIs to also add stack frames (thanks to @wroyca for suggesting this).

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Follow our [coding conventions](https://github.com/iw4x/iw4x-client/blob/master/CODESTYLE.md)
- [x] Minimize the number of commits

### Example dialog

![image](https://github.com/user-attachments/assets/3ce2947a-5619-4702-b883-1e0ce022b983)

