### PR TITLE
Fix HAVE_UNISTD_H definition with MSBuild under Wine

### DIFF
--- a/deps/premake/zlib.lua
+++ b/deps/premake/zlib.lua
@@ -16,7 +16,7 @@ function zlib.includes()
 		"ZLIB_CONST",
 	}
 
-	if os.isfile("/usr/include/unistd.h") then
+	if os.host() ~= "windows" and os.isfile("/usr/include/unistd.h") then
 		defines { "HAVE_UNISTD_H" }
 	end
 end


### PR DESCRIPTION
Wine leads Premake to incorrectly detect unistd.h as available because it exposes the host environment (e.g., /usr/include/) while emulating a Windows system. Since Wine designates the host system as Window, we can ensure that HAVE_UNISTD_H is only set when Premake is running natively (e.g., when generating MinGW Make config)