### PR TITLE
Skip MOTD periodic updates

### DIFF
--- a/src/Components/Modules/News.hpp
+++ b/src/Components/Modules/News.hpp
@@ -11,10 +11,6 @@ namespace Components
 		bool unitTest() override;
 
 	private:
-		static std::thread Thread;
-
-		static bool Terminate;
-
 		static const char* GetNewsText();
 	};
 }


### PR DESCRIPTION
Polling every 3 minutes for MOTD update is wasteful, especially since content rarely changes. Instead, we can simplify implementation by fetching MOTD once during initialization and skipping periodic updates altogether.

This also removes the wine check that prevented changelog and MOTD from loading. Not sure why it was introduced, and blame doesn't reveal much about it:

### Before

![image](https://github.com/user-attachments/assets/bf8dd3af-d01e-4eb2-9941-ba2c40f9caaa)

### After
![image](https://github.com/user-attachments/assets/a92570d0-a1ed-436e-b599-ccca13b3f66d)
