### PR TITLE
Use {} placeholders for std::format to resolve demo metadata files not being automatically deleted.

### DIFF
--- a/src/Components/Modules/Theatre.cpp
+++ b/src/Components/Modules/Theatre.cpp
@@ -358,7 +358,7 @@ namespace Components
 			{
 				Logger::Print("Deleting old demo {}\n", files[i]);
 				FileSystem::_DeleteFile("demos", files[i]);
-				FileSystem::_DeleteFile("demos", std::format("%s.json", files[i]));
+				FileSystem::_DeleteFile("demos", std::format("{}.json", files[i]));
 			}
 
 			Command::Execute(Utils::String::VA("record auto_%lld", std::time(nullptr)), true);


### PR DESCRIPTION
**What does this PR do?**

Replaces the `%s` format specifier, which is not recognized by `std::format`, with the appropriate `{}` placeholders.

**How does this PR change IW4x's behaviour?**

I noticed that the demo metadata files (i.e., `.json`) are not being deleted whilst the demo files (i.e., `.dm_13) are.

This pull request should resolve the issue by ensuring that the metadata files residing alongside the demos are also automatically deleted based on `cl_demosKeep`.