### PR TITLE
Fix/mouse clipping

### DIFF
--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -377,12 +377,13 @@ namespace Components
 
 	BOOL RawMouse::IN_RecenterMouse()
 	{
-		RECT clientRect;
+		RECT clientRect{ };
+		HWND window = Window::GetWindow();
 
-		GetClientRect(Window::GetWindow(), &clientRect);
+		GetClientRect(window, &clientRect);
 
-		ClientToScreen(Window::GetWindow(), std::bit_cast<POINT*>(&clientRect.left));
-		ClientToScreen(Window::GetWindow(), std::bit_cast<POINT*>(&clientRect.right));
+		ClientToScreen(window, std::bit_cast<POINT*>(&clientRect.left));
+		ClientToScreen(window, std::bit_cast<POINT*>(&clientRect.right));
 
 		return ClipCursor(&clientRect);
 	}
@@ -507,5 +508,10 @@ namespace Components
 
 		Window::OnWndMessage(WM_INPUT, OnRawInput);
 		Window::OnCreate(IN_RawMouse_Init);
+	}
+
+	RawMouse::~RawMouse()
+	{
+		ClipCursor(NULL);
 	}
 }

--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -359,10 +359,10 @@ namespace Components
 		R_AutoPriority = Dvar::Var("r_autopriority");
 		R_FullScreen = Dvar::Var(0x069F0DA0);
 
-#if true
+	#if true
 		// https://github.com/iw4x/iw4x-client/issues/177
 		M_RawInput.set(false);
-#endif
+	#endif
 
 	}
 
@@ -512,6 +512,10 @@ namespace Components
 
 	RawMouse::~RawMouse()
 	{
+		// Passing NULL to this function allows the cursor to move anywhere on the screen.
+		// We need to call this in the destructor because the cursor is a shared resource.
+		// This means that the cursor would remain clipped to the game window even after
+		// the game has been closed (and until something else was clicked).
 		ClipCursor(NULL);
 	}
 }

--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -512,10 +512,15 @@ namespace Components
 
 	RawMouse::~RawMouse()
 	{
-		// Passing NULL to this function allows the cursor to move anywhere on the screen.
-		// We need to call this in the destructor because the cursor is a shared resource.
-		// This means that the cursor would remain clipped to the game window even after
-		// the game has been closed (and until something else was clicked).
+		// Cursor is a shared resource. When the game window is
+		// destroyed, one might assume that the cursor
+		// automatically becomes unclipped. This is not the
+		// case—the cursor remains in a clipped state, locked to
+		// the bounds of the now-nonexistent game window until
+		// we explicitly relinquish control.
+		//
+		// https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-clipcursor#remarks
+		//
 		ClipCursor(NULL);
 	}
 }

--- a/src/Components/Modules/RawMouse.hpp
+++ b/src/Components/Modules/RawMouse.hpp
@@ -16,6 +16,7 @@ namespace Components
 	{
 	public:
 		RawMouse();
+		~RawMouse();
 
 		static void IN_MouseMove();
 


### PR DESCRIPTION
**What does this PR do?**

It ensures that the mouse cursor isn't clipped to the game window after the game has been closed.  
It's a small addition to #148, which introduced this behaviour. After quitting the game, I had to click somewhere on the desktop, otherwise I couldn't drag the mouse to another monitor (I play in fullscreen mode).

**Anything else we should know?**

This MSDN article explains why these changes are required: 
https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-clipcursor

Also... because I have severe skill issues when it comes to git, I accidentally pushed another unrelated commit.  
However, the only thing it does is to rename an engine function with its correct name.