### PR TITLE
Net code: model index bit count update

### DIFF
--- a/src/Components/Modules/ModelCache.cpp
+++ b/src/Components/Modules/ModelCache.cpp
@@ -80,6 +80,19 @@ namespace Components
 		
 		assert(std::accumulate(found.begin(), found.end(), 0u) == found.size());
 
+		for (auto& netfield : Game::netfields)
+		{
+			static_assert(offsetof(Game::entityState_s, index) == 144);
+		
+			if (netfield.offset == offsetof(Game::entityState_s, index) && (netfield.name == "index"sv || netfield.name == "index.item"sv))
+			{
+				// Some of the bit lengths for these index fields are already 15
+				assert(netfield.bits <= 15);
+				
+				Utils::Hook::Set(&netfield.bits, std::max(15u, newBitLength));
+			}
+		}
+		
 		// Reallocate G_ModelIndex
 		Utils::Hook::Set(0x420654 + 3, ModelCache::cached_models_reallocated);
 		Utils::Hook::Set(0x43BCE4 + 3, ModelCache::cached_models_reallocated);

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -22,8 +22,7 @@ namespace Game
 
 	char(*g_cmdlineCopy)[1024] = reinterpret_cast<char(*)[1024]>(0x1AD7AB0);
 
-	NetField* clientStateFields = reinterpret_cast<Game::NetField*>(0x741E40);
-	size_t clientStateFieldsCount = Utils::Hook::Get<size_t>(0x7433C8);
+	std::span<NetField> netfields(reinterpret_cast<Game::NetField*>(0x73E3A0), reinterpret_cast<Game::NetField*>(0x742FA0));
 
 	MssLocal* milesGlobal = reinterpret_cast<MssLocal*>(0x649A1A0);
 

--- a/src/Game/Game.hpp
+++ b/src/Game/Game.hpp
@@ -63,8 +63,7 @@ namespace Game
 	extern char(*g_cmdlineCopy)[1024];
 
 	// This does not belong anywhere else
-	extern NetField* clientStateFields;
-	extern size_t clientStateFieldsCount;
+	extern std::span<NetField> netfields;
 	extern MssLocal* milesGlobal;
 	extern WinVars_t* g_wv;
 


### PR DESCRIPTION
**What does this PR do?**

This PR expands the list of model indices that need to be increased to handle the increased model count.

**How does this PR change IW4x's behaviour?**

This changes the network code, so the server and client both need to be updated. Additionally, demo playback will break forward and backward compatibility due to the network code change. Maybe it's possible to check the protocol when playing back a demo and revert this change if necessary.

I presume network changes are reflected in a protocol value somewhere, which would need to be updated.

**Anything else we should know?**

This is untested.

**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Mention any [related issues](https://github.com/iw4x/iw4x-client/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/iw4x/iw4x-client/blob/master/CODESTYLE.md)
- [x] Minimize the number of commits
