### PR TITLE
add LoadMod UIScript

### DIFF
--- a/src/Components/Modules/Download.cpp
+++ b/src/Components/Modules/Download.cpp
@@ -39,7 +39,7 @@ namespace Components
 		InitiateClientDownload(map, needPassword, true);
 	}
 
-	void Download::InitiateClientDownload(const std::string& mod, bool needPassword, bool map)
+	void Download::InitiateClientDownload(const std::string& mod, bool needPassword, bool map, bool reconnect)
 	{
 		if (CLDownload.running_) return;
 
@@ -69,6 +69,7 @@ namespace Components
 		CLDownload.isMap_ = map;
 		CLDownload.mod_ = mod;
 		CLDownload.terminateThread_ = false;
+		CLDownload.reconnect_ = reconnect;
 		CLDownload.totalBytes_ = 0;
 		CLDownload.lastTimeStamp_ = 0;
 		CLDownload.downBytes_ = 0;
@@ -339,7 +340,7 @@ namespace Components
 		else
 		{
 			// Run this on the main thread
-			Scheduler::Once([]
+			Scheduler::Once([download]
 			{
 				Game::Dvar_SetString(*Game::fs_gameDirVar, mod.data());
 
@@ -353,9 +354,12 @@ namespace Components
 					Logger::Print("Restarting video...\n");
 					Command::Execute("vid_restart");
 				}
-				
-				Logger::Print("Reconnecting to server...\n");
-				Command::Execute("reconnect");
+
+				if (download->reconnect_)
+				{
+					Logger::Print("Reconnecting to server...\n");
+					Command::Execute("reconnect");
+				}
 			}, Scheduler::Pipeline::MAIN);
 		}
 	}

--- a/src/Components/Modules/Download.hpp
+++ b/src/Components/Modules/Download.hpp
@@ -14,7 +14,7 @@ namespace Components
 
 		void preDestroy() override;
 
-		static void InitiateClientDownload(const std::string& mod, bool needPassword, bool map = false);
+		static void InitiateClientDownload(const std::string& mod, bool needPassword, bool map = false, bool reconnect = true);
 		static void InitiateMapDownload(const std::string& map, bool needPassword);
 
 		static void ReplyError(mg_connection* connection, int code, std::string messageOverride = {});
@@ -30,12 +30,13 @@ namespace Components
 		class ClientDownload
 		{
 		public:
-			ClientDownload(bool isMap = false) : running_(false), valid_(false), terminateThread_(false), isMap_(isMap), totalBytes_(0), downBytes_(0), lastTimeStamp_(0), timeStampBytes_(0) {}
+			ClientDownload(bool isMap = false, bool reconnect = true) : running_(false), valid_(false), terminateThread_(false), isMap_(isMap), reconnect_(reconnect), totalBytes_(0), downBytes_(0), lastTimeStamp_(0), timeStampBytes_(0) {}
 			~ClientDownload() { this->clear(); }
 
 			bool running_;
 			bool valid_;
 			bool terminateThread_;
+			bool reconnect_;
 			bool isMap_;
 			bool isPrivate_;
 			Network::Address target_;

--- a/src/Components/Modules/Party.cpp
+++ b/src/Components/Modules/Party.cpp
@@ -27,6 +27,7 @@ namespace Components
 		std::string motd;
 		DWORD joinTime;
 		bool valid;
+		bool reconnect;
 		int matchType;
 
 		Utils::InfoString info;
@@ -59,7 +60,7 @@ namespace Components
 		return Container.target;
 	}
 
-	void Party::Connect(Network::Address target)
+	void Party::Connect(Network::Address target, bool reconnect)
 	{
 		Node::Add(target);
 
@@ -68,6 +69,7 @@ namespace Components
 		Container.joinTime = Game::Sys_Milliseconds();
 		Container.target = target;
 		Container.challenge = Utils::Cryptography::Rand::GenerateChallenge();
+		Container.reconnect = reconnect;
 
 		Network::SendCommand(Container.target, "getinfo", Container.challenge);
 
@@ -531,7 +533,7 @@ namespace Components
 					else if (!info.get("fs_game").empty() && Utils::String::ToLower(mod) != Utils::String::ToLower(info.get("fs_game")))
 					{
 						Command::Execute("closemenu popup_reconnectingtoparty");
-						Download::InitiateClientDownload(info.get("fs_game"), info.get("isPrivate") == "1"s);
+						Download::InitiateClientDownload(info.get("fs_game"), info.get("isPrivate") == "1"s, false, Container.reconnect);
 					}
 					else if ((*Game::fs_gameDirVar)->current.string[0] != '\0' && info.get("fs_game").empty())
 					{

--- a/src/Components/Modules/Party.hpp
+++ b/src/Components/Modules/Party.hpp
@@ -8,7 +8,7 @@ namespace Components
 		Party();
 
 		static Network::Address Target();
-		static void Connect(Network::Address target);
+		static void Connect(Network::Address target, bool reconnect = true);
 		static const char* GetLobbyInfo(SteamID lobby, const std::string& key);
 		static void RemoveLobby(SteamID lobby);
 

--- a/src/Components/Modules/ServerList.cpp
+++ b/src/Components/Modules/ServerList.cpp
@@ -1001,6 +1001,15 @@ namespace Components
 				}
 			});
 
+		UIScript::Add("LoadMod", []([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info)
+			{
+				auto* serverInfo = GetServer(CurrentServer);
+				if (serverInfo)
+				{
+					Party::Connect(serverInfo->addr, false);
+				}
+			});
+
 		UIScript::Add("ServerSort", []([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info)
 			{
 				const auto key = token.get<int>();


### PR DESCRIPTION
**What does this PR do?**

This PR adds the "LoadMod" UIScript, which is used by https://github.com/iw4x/iw4x-rawfiles/pull/40.
It allows loading a mod from a server without fully connecting to it.

**How does this PR change IW4x's behaviour?**

Party::Connect and Download::InitiateClientDownload have been extended with the (optional) `reconnect` argument, which defaults to true. If set to false the reconnect command thats normally executed gets skipped, so the mod will be loaded but the player won't get connected to the server, instead they get placed in the main menu.


**Did you check all the boxes?**

- [x] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [x] Mention any [related issues](https://github.com/iw4x/iw4x-client/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [x] Follow our [coding conventions](https://github.com/iw4x/iw4x-client/blob/master/CODESTYLE.md)
- [x] Minimize the number of commits
