### PR TITLE
make intro/IW_logo cinematic skippable

### DIFF
--- a/src/Components/Modules/QuickPatch.cpp
+++ b/src/Components/Modules/QuickPatch.cpp
@@ -420,7 +420,7 @@ namespace Components
 		// intro stuff
 		Utils::Hook::Nop(0x60BEE9, 5); // Don't show legals
 		Utils::Hook::Nop(0x60BEF6, 5); // Don't reset the intro dvar
-		Utils::Hook::Set<const char*>(0x60BED2, "unskippablecinematic IW_logo\n");
+		Utils::Hook::Set<const char*>(0x60BED2, "cinematic IW_logo\n");
 		Utils::Hook::Set<const char*>(0x51C2A4, "%s\\" BASEGAME "\\video\\%s.bik");
 		Utils::Hook::Set<DWORD>(0x51C2C2, 0x78A0AC);
 


### PR DESCRIPTION
makes the iw4x intro skippable.
a lot of users set the intro dvar to 0 or use the -nointro flag as its unskippable, with this change it can be skipped by clicking once.