### PR TITLE
fix: Update Discord invitation link

### DIFF
--- a/src/Components/Modules/Discord.hpp
+++ b/src/Components/Modules/Discord.hpp
@@ -7,7 +7,7 @@ namespace Components
 	public:
 		Discord();
 
-		static std::string GetDiscordServerLink() { return "https://discord.gg/2ETE8engZM"; }
+		static std::string GetDiscordServerLink() { return "https://iw4x.dev/discord"; }
 
 		void preDestroy() override;
 


### PR DESCRIPTION
**What does this PR do?**

This PR changes the Discord invitation link presented to the user when a when a crash occurs.
The new link is taken from https://github.com/iw4x (https://iw4x.dev/discord).
