### PR TITLE
Implement missing handler for Private party joining

### DIFF
--- a/src/Components/Modules/Theatre.cpp
+++ b/src/Components/Modules/Theatre.cpp
@@ -369,7 +369,7 @@ namespace Components
 	void Theatre::SV_SpawnServer_Stub()
 	{
 		StopRecording();
-		Utils::Hook::Call<void()>(0x464A60)(); // Com_SyncThreads
+		Game::Com_SyncThreads();
 	}
 
 	void Theatre::StopRecording()

--- a/src/Game/Common.cpp
+++ b/src/Game/Common.cpp
@@ -27,6 +27,7 @@ namespace Game
 	Com_UpdateSlowMotion_t Com_UpdateSlowMotion = Com_UpdateSlowMotion_t(0x60B2D0);
 	Com_Compress_t Com_Compress = Com_Compress_t(0x498220);
 	Com_LoadInfoString_t Com_LoadInfoString = Com_LoadInfoString_t(0x463500);
+	Com_SyncThreads_t Com_SyncThreads = Com_SyncThreads_t(0x464A60);
 
 	int* com_frameTime = reinterpret_cast<int*>(0x1AD8F3C);
 

--- a/src/Game/Common.hpp
+++ b/src/Game/Common.hpp
@@ -74,6 +74,9 @@ namespace Game
 	typedef char* (*Com_LoadInfoString_t)(const char* fileName, const char* fileDesc, const char* ident, char* loadBuffer);
 	extern Com_LoadInfoString_t Com_LoadInfoString;
 
+	typedef void (*Com_SyncThreads_t)();
+	extern Com_SyncThreads_t Com_SyncThreads;
+
 	extern int* com_frameTime;
 
 	extern int* com_fixedConsolePosition;

--- a/src/Game/Database.hpp
+++ b/src/Game/Database.hpp
@@ -90,6 +90,9 @@ namespace Game
 	typedef void(*DB_ReleaseXAssetHandler_t)(XAssetHeader header);
 	extern DB_ReleaseXAssetHandler_t* DB_ReleaseXAssetHandlers;
 
+	typedef void(*RMesg_SendMessages_t)();
+	extern RMesg_SendMessages_t RMesg_SendMessages;
+
 	extern XAssetHeader* DB_XAssetPool;
 	extern unsigned int* g_poolSize;
 

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -156,6 +156,8 @@ namespace Game
 	R_FlushSun_t R_FlushSun = R_FlushSun_t(0x53FB50);
 	R_SortWorldSurfaces_t R_SortWorldSurfaces = R_SortWorldSurfaces_t(0x53DC10);
 
+	RMesg_SendMessages_t RMesg_SendMessages = RMesg_SendMessages_t(0x49CC30);
+
 	GetMemory_t GetMemory = GetMemory_t(0x4E67B0);
 	GetClearedMemory_t GetClearedMemory = GetClearedMemory_t(0x422E70);
 	PS_CreatePunctuationTable_t PS_CreatePunctuationTable = PS_CreatePunctuationTable_t(0x4E6950);


### PR DESCRIPTION
**What does this PR do?**

Implements Private match functionality that was missing in IW4x - works like in the traditional game.
This reuses Party code and uses a new match type handler so **existing functionality is not affected**

**Anything else we should know?**

This does not require a protocol change!

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Mention any [related issues](https://github.com/iw4x/iw4x-client/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)

- [X] Follow our [coding conventions](https://github.com/iw4x/iw4x-client/blob/master/CODESTYLE.md)
- [X] Minimize the number of commits

![image](https://github.com/user-attachments/assets/135c7403-e740-4610-9819-18c375af4fb8)
![image_2](https://github.com/user-attachments/assets/1bc2a5d0-6c29-4645-9575-6b12cc6f18dd)
