### PR TITLE
BREAKING CHANGE: Event-driven gamepad detection

### DIFF
--- a/src/Components/Modules/Gamepad.hpp
+++ b/src/Components/Modules/Gamepad.hpp
@@ -199,8 +199,5 @@ namespace Components
 		static void GetTriggerFeedbackForEquipment(const Game::playerState_s* playerState, bool primary, GamepadControls::GamepadAPI::TriggerFeedback& feedback);
 
 		static void UpdateForceFeedback(GamepadControls::Controller& api);
-
-		std::atomic<bool> run;
-		std::thread gamepadRefreshThread;
 	};
 }

--- a/src/Components/Modules/Window.hpp
+++ b/src/Components/Modules/Window.hpp
@@ -7,6 +7,7 @@ namespace Components
 	public:
 		typedef BOOL(WndProcCallback)(WPARAM wParam, LPARAM lParam);
 		typedef void(CreateCallback)();
+		typedef void(DeviceChangeCallback)(WPARAM wParam, LPARAM lParam);
 
 		Window();
 
@@ -22,6 +23,7 @@ namespace Components
 		static HWND GetWindow();
 
 		static void OnWndMessage(UINT Msg, Utils::Slot<WndProcCallback> callback);
+		static void OnDeviceChange(Utils::Slot<DeviceChangeCallback> callback);
 
 		static void OnCreate(Utils::Slot<CreateCallback> callback);
 	private:
@@ -30,6 +32,7 @@ namespace Components
 		static Dvar::Var NativeCursor;
 		static std::unordered_map<UINT, Utils::Slot<WndProcCallback>> WndMessageCallbacks;
 		static Utils::Signal<CreateCallback> CreateSignals;
+		static Utils::Signal<DeviceChangeCallback> DeviceChangeSignals;
 
 		static HWND MainWindow;
 


### PR DESCRIPTION
Gamepad detection now relies on Windows device change notifications instead of continuous background polling

Resolves #294, resolves #286
