### PR TITLE
Fix tug-of-war between gamepad and OnMouseMove

### DIFF
--- a/src/Components/Modules/Gamepad.hpp
+++ b/src/Components/Modules/Gamepad.hpp
@@ -41,6 +41,8 @@ namespace Components
 
 		static Dvar::Var sv_allowAimAssist;
 
+		static bool IsGamePadInUse();
+
 	private:
 		enum TriggerRole
 		{
@@ -186,7 +188,6 @@ namespace Components
 		static void Key_GetCommandAssignmentInternal_Stub();
 		static void Key_SetBinding_Hk(int localClientNum, int keyNum, const char* binding);
 		static void CL_KeyEvent_Hk(const int localClientNum, const int key, const int down, const unsigned time);
-		static bool IsGamePadInUse();
 		static int CL_MouseEvent_Hk(int x, int y, int dx, int dy);
 		static bool UI_RefreshViewport_Hk();
 

--- a/src/Components/Modules/RawMouse.cpp
+++ b/src/Components/Modules/RawMouse.cpp
@@ -113,7 +113,7 @@ namespace Components
 
 	void RawMouse::IN_RawMouse_Init()
 	{
-		if (Window::GetWindow() && M_RawInput.get<bool>())
+		if (Window::GetWindow() && M_RawInput.get<bool>() && !Gamepad::IsGamePadInUse())
 		{
 			Logger::Debug("Raw Mouse Init");
 
@@ -135,7 +135,7 @@ namespace Components
 
 	void RawMouse::IN_MouseMove()
 	{
-		if (M_RawInput.get<bool>())
+		if (M_RawInput.get<bool>() && !Gamepad::IsGamePadInUse())
 		{
 			IN_RawMouseMove();
 		}


### PR DESCRIPTION
When raw input is enabled (raw_input = 1), the game begins continuously receiving OnMouseMove events, even when the mouse hasn't actually moved. The values reported in these events are questionable, but the real issue is their side effect: each such event signals to the game that the player is using the mouse, prompting it to shift input focus away from the gamepad.

This breaks the expected behavior of input switching. With event-driven input (as opposed to polling), we don't explicitly "lock in" a device. The moment a gamepad is used, the game interprets it as the active input method. But if OnMouseMove keeps firing for no good reason, it immediately overrides that with "mouse activity," creating a tug-of-war where the gamepad can't retain control.

For now skip enabling raw_mode if a gamepad is currently in use. This prevents the spurious OnMouseMove events from being generated in the first place, letting the gamepad hold control as expected.

Note that this is a hacky and partial fix. The deeper issue lies in how raw mouse input is handled overall. Without reworking that logic, particularly around how input methods assert themselves and how raw_mode is toggled, we can't resolve this cleanly without risking other side effects.


> [!CAUTION]
> A side effect of the current setup is that if you move the mouse in-game (not in-menu) while the gamepad is still connected, the mouse cursor will "drift" on its own.
>
> In practice, this may be an acceptable compromise for now. The assumption is that if you're using a gamepad, you’re not actively relying on the mouse during gameplay. We should revisit this once we dive into raw mouse input and gamepad input interaction.