### PR TITLE
Fix GetRawInputData buffer overflow with gamepad connections

### DIFF
--- a/src/Components/Modules/RawMouse.hpp
+++ b/src/Components/Modules/RawMouse.hpp
@@ -14,7 +14,7 @@ namespace Components
 		static int MouseRawX, MouseRawY;
 
 		static void IN_ClampMouseMove();
-		static BOOL OnRawInput(LPARAM lParam, WPARAM);
+		static LRESULT OnRawInput(LPARAM lParam, WPARAM);
 		static void IN_RawMouseMove();
 		static void IN_RawMouse_Init();
 		static void IN_Init();


### PR DESCRIPTION
When a gamepad is connected, GetRawInputData() may require more buffer space than the fixed sizeof(RAWINPUT) allocation provides.

Reference: https://github.com/iw4x/iw4x-client/pull/297
