### PR TITLE
Fix GS security cookie being initialized too late

### DIFF
--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -3,6 +3,9 @@
 // Unsorted function definitions
 namespace Game
 {
+	__security_init_cookie_t __security_init_cookie = __security_init_cookie_t(0x06CA062);
+	__tmainCRTStartup_t __tmainCRTStartup = __tmainCRTStartup_t(0x06BAA2F);
+
 	AngleVectors_t AngleVectors = AngleVectors_t(0x4691A0);
 
 	Cbuf_AddServerText_f_t Cbuf_AddServerText_f = Cbuf_AddServerText_f_t(0x4BB9B0);

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -3,6 +3,12 @@
 // Unsorted function definitions
 namespace Game
 {
+	typedef void(__cdecl* __security_init_cookie_t)(void);
+	extern __security_init_cookie_t __security_init_cookie;
+
+	typedef int(* __tmainCRTStartup_t)(void);
+	extern __tmainCRTStartup_t __tmainCRTStartup;
+
 	typedef void(*AngleVectors_t)(float* angles, float* forward, float* right, float* up);
 	extern AngleVectors_t AngleVectors;
 


### PR DESCRIPTION
If any /GS-protected function executes before the cookie is properly initialized, we end up   in an invalid state