### PR TITLE
add cheat dvar for disabling barrier clips

### DIFF
--- a/src/Components/Modules/PlayerMovement.cpp
+++ b/src/Components/Modules/PlayerMovement.cpp
@@ -18,6 +18,7 @@ namespace Components
 	const Game::dvar_t* PlayerMovement::BGBunnyHopAuto;
 	const Game::dvar_t* PlayerMovement::PlayerDuckedSpeedScale;
 	const Game::dvar_t* PlayerMovement::PlayerProneSpeedScale;
+	const Game::dvar_t* PlayerMovement::PMDisableBarrierClips;
 
 	void PlayerMovement::PM_PlayerTraceStub(Game::pmove_s* pm, Game::trace_t* results, const float* start, const float* end, Game::Bounds* bounds, int passEntityNum, int contentMask)
 	{
@@ -270,6 +271,20 @@ namespace Components
 		return PlayerSpectateSpeedScale;
 	}
 
+	void PlayerMovement::PMoveSingle_Stub(Game::pmove_s* pm)
+	{
+		if (PMDisableBarrierClips && PMDisableBarrierClips->current.enabled)
+		{
+			if (pm)
+			{
+				pm->tracemask &= ~0x10000;
+				pm->tracemask |= 0x400;
+			}
+		}
+
+		Game::PMoveSingle(pm);
+	}
+
 	void PlayerMovement::RegisterMovementDvars()
 	{
 		PlayerDuckedSpeedScale = Game::Dvar_RegisterFloat("player_duckedSpeedScale",
@@ -310,6 +325,9 @@ namespace Components
 
 		BGClimbAnything = Game::Dvar_RegisterBool("bg_climbAnything",
 			false, Game::DVAR_CODINFO, "Treat any surface as a ladder");
+
+		PMDisableBarrierClips = Game::Dvar_RegisterBool("pm_disableBarrierClips",
+			false, Game::DVAR_CHEAT | Game::DVAR_CODINFO, "Disable collision clips on barriers");
 	}
 
 	PlayerMovement::PlayerMovement()

--- a/src/Components/Modules/PlayerMovement.cpp
+++ b/src/Components/Modules/PlayerMovement.cpp
@@ -389,6 +389,9 @@ namespace Components
 		Utils::Hook(0x570020, PM_CrashLand_Stub, HOOK_CALL).install()->quick(); // Vec3Scale
 		Utils::Hook(0x4E9889, Jump_Check_Stub, HOOK_JUMP).install()->quick();
 
+		// No clipping on barriers
+		Utils::Hook(0x4CFF5C, PMoveSingle_Stub, HOOK_CALL).install()->quick(); // Pmove
+
 		GSC::Script::AddMethod("IsSprinting", GScr_IsSprinting);
 
 		RegisterMovementDvars();

--- a/src/Components/Modules/PlayerMovement.hpp
+++ b/src/Components/Modules/PlayerMovement.hpp
@@ -26,6 +26,7 @@ namespace Components
 		static const Game::dvar_t* BGBunnyHopAuto;
 		static const Game::dvar_t* PlayerDuckedSpeedScale;
 		static const Game::dvar_t* PlayerProneSpeedScale;
+		static const Game::dvar_t* PMDisableBarrierClips;
 
 		static void PM_PlayerTraceStub(Game::pmove_s* pm, Game::trace_t* results, const float* start, const float* end, Game::Bounds* bounds, int passEntityNum, int contentMask);
 		static void PM_PlayerDuckedSpeedScaleStub();
@@ -54,5 +55,7 @@ namespace Components
 		static const Game::dvar_t* Dvar_RegisterSpectateSpeedScale(const char* dvarName, float value, float min, float max, unsigned __int16 flags, const char* description);
 
 		static void RegisterMovementDvars();
+
+		static void PMoveSingle_Stub(Game::pmove_s* pm);
 	};
 }

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -148,6 +148,8 @@ namespace Game
 
 	Playlist_ParsePlaylists_t Playlist_ParsePlaylists = Playlist_ParsePlaylists_t(0x4295A0);
 
+	PMoveSingle_t PMoveSingle = PMoveSingle_t(0x5743E0);
+
 	R_AddCmdDrawStretchPic_t R_AddCmdDrawStretchPic = R_AddCmdDrawStretchPic_t(0x509770);
 	R_AllocStaticIndexBuffer_t R_AllocStaticIndexBuffer = R_AllocStaticIndexBuffer_t(0x51E7A0);
 	R_Cinematic_StartPlayback_Now_t R_Cinematic_StartPlayback_Now = R_Cinematic_StartPlayback_Now_t(0x51C5B0);

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -374,6 +374,9 @@ namespace Game
 	typedef void(*Playlist_ParsePlaylists_t)(const char* data);
 	extern Playlist_ParsePlaylists_t Playlist_ParsePlaylists;
 
+	typedef void(*PMoveSingle_t)(pmove_s* pm);
+	extern PMoveSingle_t PMoveSingle;
+
 	typedef Font_s*(*R_RegisterFont_t)(const char* asset, int safe);
 	extern R_RegisterFont_t R_RegisterFont;
 


### PR DESCRIPTION
**What does this PR do?**

This PR adds a toggleable cheat dvar for disabling barrier clips on various maps. Essentially, this lets you walk on any surface/roof that is usually clipped off (it's pretty cool ngl)
<img width="1920" height="1080" alt="{26661931-3876-4882-A494-B9DB4FB9D5C9}" src="https://github.com/user-attachments/assets/eee53028-492c-4404-83b2-d20c01438e8e" />


**How does this PR change IW4x's behaviour?**

This PR simply hooks a PMoveSingle call in PMove to do some logic on the pm tracemask. The dvar is verified to not be nullptr and so is the `pm` state.

**Anything else we should know?**

Nope!

**Did you check all the boxes?**

- [X] Focus on a single fix or feature; remove any unrelated formatting or code changes
- [X] Mention any [related issues](https://github.com/iw4x/iw4x-client/issues) (put `closes #XXXX` in comment to auto-close issue when PR is merged)
- [X] Follow our [coding conventions](https://github.com/iw4x/iw4x-client/blob/master/CODESTYLE.md)
- [X] Minimize the number of commits
