### PR TITLE
fix: potential stack corruption in CG_FireWeapon_FireSoundHk

### DIFF
--- a/src/Components/Modules/Rumble.cpp
+++ b/src/Components/Modules/Rumble.cpp
@@ -751,16 +751,16 @@ namespace Components
 		{
 			pushad;
 
-			push bx
-				push[esp + 0x20 + 0x28 + 0x2] // weapon
-				push esi // cent
-				push ebp
+			push ebx
+			push[esp + 0x20 + 0x28 + 0x4] // weapon
+			push esi // cent
+			push ebp
 
-				call CG_FireWeapon_Rumble
+			call CG_FireWeapon_Rumble
 
-				add esp, 0x4 * 3 + 0x2
+			add esp, 0x4 * 4
 
-				popad;
+			popad;
 
 			// OG code
 			sub esp, 0x10;


### PR DESCRIPTION
https://github.com/iw4x/iw4x-client/blob/72d94fda4640cd2e7a6354f8c0adb134a31e825d/src/Components/Modules/Rumble.cpp#L754-L761

As I was trying to figure out why the game was crashing for me, I eventually found that this assembly was potentially corrupting the stack. If during gameplay none of the rumbles are registered the game eventually gets to this point:
https://github.com/iw4x/iw4x-client/blob/72d94fda4640cd2e7a6354f8c0adb134a31e825d/src/Components/Modules/Rumble.cpp#L296

The logger internally calls `OutputDebugStringA` which I assume throws an exception (`kernelbase.RaiseException`), maybe unwinds the stack and runs into the stack issue mentioned above.

I did my testing with the debug build of iw4x. With the VS2022 debugger attached there was no crash and I couldn't see any issue. With x32dbg attached the game crashed. Without any debugger attached the game also crashed. I could imagine that the Windows API assumes that the value of the ESP register is a multiple of 4, which is not the case after the push of a 16 bit register (`push bx`).