### PR TITLE
fix: avoid demo time out after map loading

### DIFF
--- a/src/Components/Modules/Theatre.hpp
+++ b/src/Components/Modules/Theatre.hpp
@@ -44,6 +44,7 @@ namespace Components
 		static unsigned int GetDemoCount();
 		static const char* GetDemoText(unsigned int item, int column);
 		static void SelectDemo(unsigned int index);
+		static bool AdjustTimeDelta();
 
 		static void GamestateWriteStub(Game::msg_t* msg, char byte);
 		static void RecordGamestateStub();


### PR DESCRIPTION
* Related to: https://github.com/iw4x/iw4x-client/pull/330

This makes it unnecessary to use the 'demoback' command at the start of a demo.

https://github.com/iw4x/iw4x-client/blob/1b14e3d7b25f12b1b072a5944b67bc918e4e06ed/src/Components/Modules/Theatre.cpp#L297
Technically, this wouldn't be necessary anymore if this PR gets merged. As far as I can see, this only applies to demos launched from the theater mode, though, and not the regular demo command.