### PR TITLE
Remove migration of old guid.dat

### DIFF
--- a/src/Components/Modules/Auth.cpp
+++ b/src/Components/Modules/Auth.cpp
@@ -387,19 +387,6 @@ namespace Components
 		if (!force && GuidKey.isValid()) return;
 
 		const auto guidPath = GetGUIDFilePath();
-
-#ifndef REGENERATE_INVALID_KEY
-		// Migrate old file
-		const auto oldGuidPath = "players/guid.dat";
-		if (Utils::IO::FileExists(oldGuidPath))
-		{
-			if (MoveFileA(oldGuidPath, guidPath.data()))
-			{
-				Utils::IO::RemoveFile(oldGuidPath);
-			}
-		}
-#endif
-
 		const auto guidFile = Utils::IO::ReadFile(guidPath);
 
 		Proto::Auth::Certificate cert;


### PR DESCRIPTION
This will prevent users who download repacks having the same GUID.