### PR TITLE
Add net_alwaysUseNodes to prefer node discovery over the master path

### DIFF
--- a/src/Components/Modules/Node.cpp
+++ b/src/Components/Modules/Node.cpp
@@ -15,6 +15,7 @@ namespace Components
 	bool Node::WasIngame = false;
 
 	const Game::dvar_t* Node::net_natFix;
+	const Game::dvar_t* Node::net_alwaysUseNodes;
 
 	bool Node::Entry::isValid() const
 	{
@@ -183,7 +184,7 @@ namespace Components
 
 		if (!Dedicated::IsEnabled())
 		{
-			if (ServerList::UseMasterServer) return; // don't run node frame if master server is active
+			if (ServerList::UseMasterServer && !net_alwaysUseNodes->current.enabled) return; // don't run node frame if master server is active
 
 			if (Game::CL_GetLocalClientConnectionState(0) != Game::CA_DISCONNECTED)
 			{
@@ -265,7 +266,7 @@ namespace Components
 
 		if (list.isnode() && (!list.port() || list.port() == address.getPort()))
 		{
-			if (!Dedicated::IsEnabled() && ServerList::IsOnlineList() && !ServerList::UseMasterServer && list.protocol() == PROTOCOL)
+			if (!Dedicated::IsEnabled() && ServerList::IsOnlineList() && (!ServerList::UseMasterServer || net_alwaysUseNodes->current.enabled) && list.protocol() == PROTOCOL)
 			{
 #ifdef NODE_SYSTEM_DEBUG
 				Logger::Debug("Inserting {} into the serverlist", address.getString());
@@ -402,6 +403,7 @@ namespace Components
 		}
 
 		net_natFix = Game::Dvar_RegisterBool("net_natFix", false, 0, "Fix node registration for certain firewalls/routers");
+		net_alwaysUseNodes = Game::Dvar_RegisterBool("net_alwaysUseNodes", false, Game::DVAR_ARCHIVE, "Always use node system instead of master server");
 
 		Scheduler::Loop([]
 			{

--- a/src/Components/Modules/Node.hpp
+++ b/src/Components/Modules/Node.hpp
@@ -47,6 +47,7 @@ namespace Components
 		static bool WasIngame;
 
 		static const Game::dvar_t* net_natFix;
+		static const Game::dvar_t* net_alwaysUseNodes;
 
 		static void HandleResponse(const Network::Address& address, const std::string& data);
 

--- a/src/Components/Modules/ServerList.cpp
+++ b/src/Components/Modules/ServerList.cpp
@@ -375,6 +375,17 @@ namespace Components
 		}
 		else if (IsOnlineList())
 		{
+			const auto* alwaysUseNodes = Game::Dvar_FindVar("net_alwaysUseNodes");
+
+			if (alwaysUseNodes && alwaysUseNodes->current.enabled)
+			{
+				UseMasterServer = false;
+				Logger::Print("net_alwaysUseNodes is enabled, using node system\n");
+				Toast::Show("cardicon_headshot", "Server Browser", "Fetching servers from nodes...", 3000);
+				Node::Synchronize();
+				return;
+			}
+
 			const auto masterPort = (*Game::com_masterPort)->current.unsignedInt;
 			const auto* masterServerName = (*Game::com_masterServerName)->current.string;
 


### PR DESCRIPTION
We accommodates a now familiar pattern in parts of Russia where traffic to the OVH-hosted master is intermittently filtered or de-prioritized by authorities/regional carriers. Through no particular engineering of ours, Node discovery tends to slip through unaffected, a small mercy, all things considered.