### PR TITLE
Make Zonebuilder quit normally

### DIFF
--- a/src/Components/Modules/ZoneBuilder.cpp
+++ b/src/Components/Modules/ZoneBuilder.cpp
@@ -919,7 +919,7 @@ namespace Components
 
 	void ZoneBuilder::Com_Quitf_t()
 	{
-		ExitProcess(0);
+		Game::Sys_Quit();
 	}
 
 	void ZoneBuilder::CommandThreadCallback()

--- a/src/Game/System.cpp
+++ b/src/Game/System.cpp
@@ -26,6 +26,7 @@ namespace Game
 	Sys_CreateFile_t Sys_CreateFile = Sys_CreateFile_t(0x4B2EF0);
 	Sys_OutOfMemErrorInternal_t Sys_OutOfMemErrorInternal = Sys_OutOfMemErrorInternal_t(0x4B2E60);
 	Sys_QuitAndStartProcess_t Sys_QuitAndStartProcess = Sys_QuitAndStartProcess_t(0x45FCF0);
+	Sys_Quit_t Sys_Quit = Sys_Quit_t(0x4D6970);
 
 	char(*sys_exitCmdLine)[1024] = reinterpret_cast<char(*)[1024]>(0x649FB68);
 	char(*sys_cmdline)[1024] = reinterpret_cast<char(*)[1024]>(0x649F760);

--- a/src/Game/System.hpp
+++ b/src/Game/System.hpp
@@ -74,6 +74,9 @@ namespace Game
 	typedef void(*Sys_QuitAndStartProcess_t)(const char*);
 	extern Sys_QuitAndStartProcess_t Sys_QuitAndStartProcess;
 
+	typedef void(*Sys_Quit_t)();
+	extern Sys_Quit_t Sys_Quit;
+
 	extern char(*sys_exitCmdLine)[1024];
 	extern char(*sys_cmdline)[1024];
 


### PR DESCRIPTION
This prevents a non-zero error code (almost guaranteed to happen otherwise) by performing uninitialization properly, like the game does it.

This was the bug:
```
>iw4x.exe -nosteam +quit

>echo %errorlevel%
0

>iw4x.exe -zonebuilder +quit

>echo %errorlevel%
-1073740791
```

And now it's like that
```
>iw4x.exe -zonebuilder +quit

>echo %errorlevel%
0
```

Pretty big thing because it prevents MPU from working normally otherwise! (A non zero error code will indicate that zonebuilder crashed, which MPU will take as a fatal and stop copying files - as it should)