### PR TITLE
Muting a player clientside now also mutes their chat messages

### DIFF
--- a/src/Components/Modules/Chat.cpp
+++ b/src/Components/Modules/Chat.cpp
@@ -205,8 +205,6 @@ namespace Components
 		{
 			if (Voice::CL_IsPlayerMuted(i))
 			{
-				const auto& user = Game::g_serverSession->dyn.users[i];
-
 				int gotName = Game::CL_GetClientName(0, i, nameBuffer, ARRAYSIZE(nameBuffer));
 				if (gotName)
 				{

--- a/src/Components/Modules/Chat.cpp
+++ b/src/Components/Modules/Chat.cpp
@@ -188,7 +188,7 @@ namespace Components
 
 		if (index == std::string::npos)
 		{
-			// This is likely a server say or an unfiltered message
+			// This is likely a server say or an unauthored message
 			return false;
 		}
 
@@ -210,7 +210,6 @@ namespace Components
 				int gotName = Game::CL_GetClientName(0, i, nameBuffer, ARRAYSIZE(nameBuffer));
 				if (gotName)
 				{
-					// We use "ends with" here because we know the Team Name is prefixed
 					std::string rawPlayerName = TextRenderer::StripColors(nameBuffer);
 					if (authorName == rawPlayerName)
 					{

--- a/src/Components/Modules/Chat.hpp
+++ b/src/Components/Modules/Chat.hpp
@@ -47,5 +47,7 @@ namespace Components
 		static int GetCallbackReturn();
 		static int ChatCallback(Game::gentity_s* self, const char* codePos, const char* message, int mode);
 		static void AddScriptFunctions();
+
+		static bool CL_IsMessageFromMutedUser(const std::string& txt);
 	};
 }

--- a/src/Components/Modules/Voice.hpp
+++ b/src/Components/Modules/Voice.hpp
@@ -13,6 +13,10 @@ namespace Components
 		static void SV_MuteClient(int muteClientIndex);
 		static void SV_UnmuteClient(int muteClientIndex);
 
+		static bool CL_IsPlayerMuted(int clientIndex) {
+			return CL_IsPlayerMuted_Hk(Game::g_serverSession, 0, clientIndex);
+		};
+
 	private:
 		static constexpr auto MAX_VOICE_PACKET_DATA = 256;
 		static constexpr auto MAX_SERVER_QUEUED_VOICE_PACKETS = 40;


### PR DESCRIPTION
I'm going for a "better than nothing" approach here.

Muting somebody now mutes their chat messages too and it should be pretty safe & complete.
However team messages are currently not affected because checking team name & separating it from player name introduces a number of caveats, which would require heavier modifications (and possibly a protocol change). 
So at least right now all (non-team) authored messages (coming from a player) will be correctly filtered if you muted the author in your "Mute player" menu. Better than the mute not working at all

https://github.com/user-attachments/assets/c88e55d4-9a3b-4ab3-b278-ac198f2e6bd2

