### PR TITLE
PR to add Treyarc Function of ViewmodelFX and further improve!

### DIFF
--- a/src/Components/Loader.cpp
+++ b/src/Components/Loader.cpp
@@ -72,6 +72,7 @@
 #include "Modules/Window.hpp"
 
 #include "Modules/BotLib/lPrecomp.hpp"
+#include "Modules/ViewModelFxSetup.hpp"
 
 namespace Components
 {
@@ -180,6 +181,7 @@ namespace Components
 		Register(new GSC::GSC());
 
 		Register(new BotLib::lPrecomp());
+		Register(new ViewModelFxSetup::Setup());
 
 		Pregame = false;
 	}

--- a/src/Components/Loader.cpp
+++ b/src/Components/Loader.cpp
@@ -73,6 +73,7 @@
 #include "Modules/Sound.hpp"
 
 #include "Modules/BotLib/lPrecomp.hpp"
+#include "Modules/ViewModelFxSetup.hpp"
 
 namespace Components
 {
@@ -182,6 +183,7 @@ namespace Components
 		Register(new GSC::GSC());
 
 		Register(new BotLib::lPrecomp());
+		Register(new ViewModelFxSetup::Setup());
 
 		Pregame = false;
 	}

--- a/src/Components/Loader.hpp
+++ b/src/Components/Loader.hpp
@@ -68,3 +68,4 @@ namespace Components
 #include "Modules/Rumble.hpp"
 
 #include "Modules/GSC/GSC.hpp"
+#include "Modules/ViewModelFxSetup.hpp"

--- a/src/Components/Modules/ViewModelFx.cpp
+++ b/src/Components/Modules/ViewModelFx.cpp
@@ -41,7 +41,7 @@ namespace Components::ViewModelFxSetup
 			if (!Game::DObjGetBoneIndex(reinterpret_cast<int>(dobj), tagName, &boneIdx))
 			{
 				Game::Scr_Error(Utils::String::VA(
-					"PlayViewmodelFX(): clientNum '%d' does not have bone '%s'",
+					"PlayViewmodelFX(): clientNum '%s' does not have bone '%s'",
 					clientNum,
 					Game::SL_ConvertToString(tagName)
 				));
@@ -91,10 +91,21 @@ namespace Components::ViewModelFxSetup
 			}
 		});
 
+		GSC::Script::AddMethod("setanim", [](Game::scr_entref_t entref)
+		{
+			auto* ent = GSC::Script::Scr_GetPlayerEntity(entref);
+			if (!ent)
+				return;
+
+			int anim = Game::Scr_GetInt(0);
+
+			for (int i = 0; i < 2; i++)
+				ent->client->ps.weapState[i].weapAnim = anim;
+		});
+	}
 
 	Setup::Setup()
 	{
 		Add_GSC_Functions();
 	}
 }
-

--- a/src/Components/Modules/ViewModelFx.cpp
+++ b/src/Components/Modules/ViewModelFx.cpp
@@ -1,0 +1,111 @@
+#include <STDInclude.hpp>
+#include "Components/Modules/GSC/Script.hpp"
+#include "Components/Modules/GSC/ScriptExtension.hpp"
+#include "Components/Modules/Weapon.hpp"
+#include "Components/Modules/ViewModelFxSetup.hpp"
+
+namespace Components::ViewModelFxSetup
+{
+	static char cg_weaponsArray[32 * Weapon::WEAPON_LIMIT];
+
+	void Add_GSC_Functions()
+	{
+		// 3arc function for iw game
+		GSC::Script::AddFunction("PlayViewmodelFX", []
+		{
+			if (Game::Scr_GetNumParam() != 2)
+			{
+				Game::Scr_Error("PlayViewmodelFX() called with wrong params.\n");
+				return;
+			}
+
+			const char* fxName = Game::Scr_GetString(0); // FX name string
+			Game::scr_string_t tagName = Game::Scr_GetConstString(1); // Bone/tag
+
+			Game::FxEffectDef* fx = Game::DB_FindXAssetHeader(Game::ASSET_TYPE_FX, fxName).fx;
+			if (!fx)
+			{
+				Game::Scr_Error(Utils::String::VA("PlayViewmodelFX(): FX '%s' not found", fxName));
+				return;
+			}
+
+			int clientNum = 0; // local player
+			const Game::DObj* dobj = Game::Com_GetClientDObj(clientNum, 0);
+			if (!dobj)
+			{
+				Game::Scr_Error("PlayViewmodelFX(): Could not get DObj for local player");
+				return;
+			}
+
+			unsigned char boneIdx = 0;
+			if (!Game::DObjGetBoneIndex(reinterpret_cast<int>(dobj), tagName, &boneIdx))
+			{
+				Game::Scr_Error(Utils::String::VA(
+					"PlayViewmodelFX(): clientNum '%s' does not have bone '%s'",
+					clientNum,
+					Game::SL_ConvertToString(tagName)
+				));
+				return;
+			}
+
+			int dobjHandle = dobj->entnum;
+			Game::CG_PlayBoltedEffect(0, fx, dobjHandle, tagName);
+		});
+
+		GSC::Script::AddFunction("PVMFX_BOTH", []
+		{
+			if (Game::Scr_GetNumParam() != 2)
+			{
+				Game::Scr_Error("PVMFX_BOTH() called with wrong params. Expected 2.\n");
+				return;
+			}
+
+			const char* fxName = Game::Scr_GetString(0); // FX name string
+			Game::scr_string_t tagName = Game::Scr_GetConstString(1); // Bone/tag
+
+			Game::FxEffectDef* fx = Game::DB_FindXAssetHeader(Game::ASSET_TYPE_FX, fxName).fx;
+			if (!fx)
+			{
+				Game::Scr_Error(Utils::String::VA("PVMFX_BOTH(): FX '%s' not found", fxName));
+				return;
+			}
+
+			for (int hand = 0; hand <= 1; ++hand)
+			{
+				int fpDObjHandle = Game::CG_WeaponDObjHandle(hand);
+				if (fpDObjHandle)
+				{
+					Game::CG_PlayBoltedEffect(0, fx, fpDObjHandle, tagName);
+
+					Game::CG_StopBoltedEffect(0, 0, fpDObjHandle, tagName);
+				}
+			}
+
+			int clientNum = 0;
+			const Game::DObj* tpDObj = Game::Com_GetClientDObj(clientNum, 0);
+			if (tpDObj)
+			{
+				Game::CG_PlayBoltedEffect(0, fx, tpDObj->entnum, tagName);
+
+				Game::CG_StopBoltedEffect(0, 0, tpDObj->entnum, tagName);
+			}
+		});
+
+		GSC::Script::AddMethod("setanim", [](Game::scr_entref_t entref)
+		{
+			auto* ent = GSC::Script::Scr_GetPlayerEntity(entref);
+			if (!ent)
+				return;
+
+			int anim = Game::Scr_GetInt(0);
+
+			for (int i = 0; i < 2; i++)
+				ent->client->ps.weapState[i].weapAnim = anim;
+		});
+	}
+
+	Setup::Setup()
+	{
+		Add_GSC_Functions();
+	}
+}

--- a/src/Components/Modules/ViewModelFx.cpp
+++ b/src/Components/Modules/ViewModelFx.cpp
@@ -41,7 +41,7 @@ namespace Components::ViewModelFxSetup
 			if (!Game::DObjGetBoneIndex(reinterpret_cast<int>(dobj), tagName, &boneIdx))
 			{
 				Game::Scr_Error(Utils::String::VA(
-					"PlayViewmodelFX(): clientNum '%s' does not have bone '%s'",
+					"PlayViewmodelFX(): clientNum '%d' does not have bone '%s'",
 					clientNum,
 					Game::SL_ConvertToString(tagName)
 				));
@@ -90,19 +90,6 @@ namespace Components::ViewModelFxSetup
 				Game::CG_StopBoltedEffect(0, 0, tpDObj->entnum, tagName);
 			}
 		});
-
-		GSC::Script::AddMethod("setanim", [](Game::scr_entref_t entref)
-		{
-			auto* ent = GSC::Script::Scr_GetPlayerEntity(entref);
-			if (!ent)
-				return;
-
-			int anim = Game::Scr_GetInt(0);
-
-			for (int i = 0; i < 2; i++)
-				ent->client->ps.weapState[i].weapAnim = anim;
-		});
-	}
 
 	Setup::Setup()
 	{

--- a/src/Components/Modules/ViewModelFx.cpp
+++ b/src/Components/Modules/ViewModelFx.cpp
@@ -41,7 +41,7 @@ namespace Components::ViewModelFxSetup
 			if (!Game::DObjGetBoneIndex(reinterpret_cast<int>(dobj), tagName, &boneIdx))
 			{
 				Game::Scr_Error(Utils::String::VA(
-					"PlayViewmodelFX(): clientNum '%s' does not have bone '%s'",
+					"PlayViewmodelFX(): clientNum '%d' does not have bone '%s'",
 					clientNum,
 					Game::SL_ConvertToString(tagName)
 				));

--- a/src/Components/Modules/ViewModelFx.cpp
+++ b/src/Components/Modules/ViewModelFx.cpp
@@ -91,22 +91,10 @@ namespace Components::ViewModelFxSetup
 			}
 		});
 
-		GSC::Script::AddMethod("setanim", [](Game::scr_entref_t entref)
-		{
-			auto* ent = GSC::Script::Scr_GetPlayerEntity(entref);
-			if (!ent || !ent->client)
-				return;
-
-
-			int anim = Game::Scr_GetInt(0);
-
-			for (int i = 0; i < 2; i++)
-				ent->client->ps.weapState[i].weapAnim = anim;
-		});
-	}
 
 	Setup::Setup()
 	{
 		Add_GSC_Functions();
 	}
 }
+

--- a/src/Components/Modules/ViewModelFx.cpp
+++ b/src/Components/Modules/ViewModelFx.cpp
@@ -94,8 +94,9 @@ namespace Components::ViewModelFxSetup
 		GSC::Script::AddMethod("setanim", [](Game::scr_entref_t entref)
 		{
 			auto* ent = GSC::Script::Scr_GetPlayerEntity(entref);
-			if (!ent)
+			if (!ent || !ent->client)
 				return;
+
 
 			int anim = Game::Scr_GetInt(0);
 

--- a/src/Components/Modules/ViewModelFx.cpp
+++ b/src/Components/Modules/ViewModelFx.cpp
@@ -90,6 +90,7 @@ namespace Components::ViewModelFxSetup
 				Game::CG_StopBoltedEffect(0, 0, tpDObj->entnum, tagName);
 			}
 		});
+	}
 
 	Setup::Setup()
 	{

--- a/src/Components/Modules/ViewModelFxSetup.hpp
+++ b/src/Components/Modules/ViewModelFxSetup.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace Components::ViewModelFxSetup
+{
+	class Setup : public Component
+	{
+	public:
+		Setup();
+	};
+}

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -415,6 +415,11 @@ namespace Game
 
 	const char* logFileName = reinterpret_cast<const char*>(0x730130);
 
+	DObjGetBoneIndex_t DObjGetBoneIndex = reinterpret_cast<DObjGetBoneIndex_t>(0x504F20);
+	Com_GetClientDObj_t Com_GetClientDObj = reinterpret_cast<Com_GetClientDObj_t>(0x41FF50);
+	CG_WeaponDObjHandle_t CG_WeaponDObjHandle = reinterpret_cast<CG_WeaponDObjHandle_t>(0x41DB70);
+	CG_StopBoltedEffect_t CG_StopBoltedEffect = reinterpret_cast<CG_StopBoltedEffect_t>(0x44C230);
+
 	const char* TableLookup(StringTable* stringtable, int row, int column)
 	{
 		if (!stringtable || !stringtable->values || row >= stringtable->rowCount || column >= stringtable->columnCount) return "";

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -420,6 +420,7 @@ namespace Game
 	CG_WeaponDObjHandle_t CG_WeaponDObjHandle = reinterpret_cast<CG_WeaponDObjHandle_t>(0x41DB70);
 	CG_StopBoltedEffect_t CG_StopBoltedEffect = reinterpret_cast<CG_StopBoltedEffect_t>(0x44C230);
 
+
 	const char* TableLookup(StringTable* stringtable, int row, int column)
 	{
 		if (!stringtable || !stringtable->values || row >= stringtable->rowCount || column >= stringtable->columnCount) return "";

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -423,6 +423,7 @@ namespace Game
 	CG_WeaponDObjHandle_t CG_WeaponDObjHandle = reinterpret_cast<CG_WeaponDObjHandle_t>(0x41DB70);
 	CG_StopBoltedEffect_t CG_StopBoltedEffect = reinterpret_cast<CG_StopBoltedEffect_t>(0x44C230);
 
+
 	const char* TableLookup(StringTable* stringtable, int row, int column)
 	{
 		if (!stringtable || !stringtable->values || row >= stringtable->rowCount || column >= stringtable->columnCount) return "";

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -418,6 +418,11 @@ namespace Game
 
 	const char* logFileName = reinterpret_cast<const char*>(0x730130);
 
+	DObjGetBoneIndex_t DObjGetBoneIndex = reinterpret_cast<DObjGetBoneIndex_t>(0x504F20);
+	Com_GetClientDObj_t Com_GetClientDObj = reinterpret_cast<Com_GetClientDObj_t>(0x41FF50);
+	CG_WeaponDObjHandle_t CG_WeaponDObjHandle = reinterpret_cast<CG_WeaponDObjHandle_t>(0x41DB70);
+	CG_StopBoltedEffect_t CG_StopBoltedEffect = reinterpret_cast<CG_StopBoltedEffect_t>(0x44C230);
+
 	const char* TableLookup(StringTable* stringtable, int row, int column)
 	{
 		if (!stringtable || !stringtable->values || row >= stringtable->rowCount || column >= stringtable->columnCount) return "";

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -48,6 +48,18 @@ namespace Game
 	typedef const DObj*(*CG_GetBoneIndex_t)(int localClientNum, unsigned int boneName, char* boneIndex);
 	extern CG_GetBoneIndex_t CG_GetBoneIndex;
 
+	typedef int(__cdecl* DObjGetBoneIndex_t)(int a1, int a2, unsigned char* a3);
+	extern DObjGetBoneIndex_t DObjGetBoneIndex;
+
+	typedef DObj* (__cdecl* Com_GetClientDObj_t)(int handle, int localClientNum);
+	extern Com_GetClientDObj_t Com_GetClientDObj;
+
+	typedef int(__cdecl* CG_WeaponDObjHandle_t)(int hand);
+	extern CG_WeaponDObjHandle_t CG_WeaponDObjHandle;
+
+	typedef char* (__cdecl* CG_StopBoltedEffect_t)(int localClientNum, int effectHandle, int dobjHandle, int tagName);
+	extern CG_StopBoltedEffect_t CG_StopBoltedEffect;
+
 	typedef void(*CG_ScoresDown_f_t)();
 	extern CG_ScoresDown_f_t CG_ScoresDown_f;
 

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -51,6 +51,18 @@ namespace Game
 	typedef const DObj*(*CG_GetBoneIndex_t)(int localClientNum, unsigned int boneName, char* boneIndex);
 	extern CG_GetBoneIndex_t CG_GetBoneIndex;
 
+	typedef int(__cdecl* DObjGetBoneIndex_t)(int a1, int a2, unsigned char* a3);
+	extern DObjGetBoneIndex_t DObjGetBoneIndex;
+
+	typedef DObj* (__cdecl* Com_GetClientDObj_t)(int handle, int localClientNum);
+	extern Com_GetClientDObj_t Com_GetClientDObj;
+
+	typedef int(__cdecl* CG_WeaponDObjHandle_t)(int hand);
+	extern CG_WeaponDObjHandle_t CG_WeaponDObjHandle;
+
+	typedef char* (__cdecl* CG_StopBoltedEffect_t)(int localClientNum, int effectHandle, int dobjHandle, int tagName);
+	extern CG_StopBoltedEffect_t CG_StopBoltedEffect;
+
 	typedef void(*CG_ScoresDown_f_t)();
 	extern CG_ScoresDown_f_t CG_ScoresDown_f;
 


### PR DESCRIPTION
ALL CREDITS TO ANTIGA @EINFLICTOR 

Viewmodel Fx at its current state only works on local host.

Pr is to get this code out into the world! Like i said for now Fx is only playing on local client, for all clients to see their own viewmodelfx in an online server this code still needs work. This is what im hoping to achieve in the end goal of releasing the code!

 Function naming could probably be better on a release version if it ever gets improved. 

heres some base gsc so you can see how the functionality works within gsc. 


If you are interested in reviewing code and need a fast mod to test on, ill send the tesla gun mod your way. Just dm on cord @myluckyneo

```
Init()
{
	level.tesla_gun = "t4_dg2_mp";
	replaceFunc( maps\mp\gametypes\_gamelogic::matchStartTimerPC, maps\mp\gametypes\_gamelogic::matchStartTimerSkip );
	level thread onPlayerConnected();
	
	level._teslaFX = [];

	level._teslaFX["tesla_viewmodel_view"]  = "sk/t5/weapons/tesla/fx_zombie_tesla_tube_view";
	level._teslaFX["tesla_viewmodel_view2"] = "sk/t5/weapons/tesla/fx_zombie_tesla_tube_view2";
	level._teslaFX["tesla_viewmodel_view3"] = "sk/t5/weapons/tesla/fx_zombie_tesla_tube_view3";
	level._teslaFX["tesla_viewmodel_rail"] = "sk/t5/weapons/tesla/fx_zombie_tesla_rail_view";
}

onPlayerConnected()
{
	for( ;; )
	{
		level waittill( "connected", player );
		player thread bulbFX();
		player thread afterShotFX();
		player thread railIdleFX();
	    player thread onPlayerSpawned();
    }
}

// Called on player spawn (server)
onPlayerSpawned()
{
    self endon("disconnect");

    self waittill("spawned_player");

    // Give weapon (server-side)
    self takeAllWeapons();
    self giveWeapon(level.tesla_gun);
    wait 1;
    self switchToWeapon(level.tesla_gun);
}

railIdleFX()
{
	level endon("game_ended");
	for (;;)
	{
		wait 10;
		PVMFX_BOTH(level._teslaFX["tesla_viewmodel_rail"], "tag_flash");
	}
}

bulbFX()
{
    level endon("game_ended");

    for (;;)
    {
		
        wait 0.1;
		if( self getCurrentWeapon() != level.tesla_gun )
			continue;

        ammo = self GetWeaponAmmoClip( self getCurrentWeapon() );

        switch(ammo)
        {
            case 3:
                PVMFX_BOTH(level._teslaFX["tesla_viewmodel_view"], "tag_brass");
                break;
            case 2:
                PVMFX_BOTH(level._teslaFX["tesla_viewmodel_view2"], "tag_brass");
                break;
            case 1:
                PVMFX_BOTH(level._teslaFX["tesla_viewmodel_view3"], "tag_brass");
                break;
		
        }
    }
}
afterShotFX()
{
    level endon("game_ended");
    self endon("disconnect");

    for (;;)
    {
        self waittill("weapon_fired", weapon);

        if (weapon == level.tesla_gun)
        {
            wait 0.1;
            PVMFX_BOTH(level._teslaFX["tesla_viewmodel_rail"], "tag_flash");
            IPrintLnBold(">> [TESLA DEBUG] Local viewmodel FX played for ", self.name);
        }
    }
}
```

