### PR TITLE
Fix memory leak in Auth::GetMachineEntropy

### DIFF
--- a/src/Components/Modules/Auth.cpp
+++ b/src/Components/Modules/Auth.cpp
@@ -544,14 +544,13 @@ namespace Components
 			if (dwResult == ERROR_BUFFER_OVERFLOW)  // This is what we're expecting
 			{
 				// Now allocate a structure of the required size.
-				auto pIpAdapterInfo = std::unique_ptr<IP_ADAPTER_INFO, decltype(&free)>(
-					reinterpret_cast<PIP_ADAPTER_INFO>(malloc(outBufLen)), free);
-				if (pIpAdapterInfo)
+				std::vector<std::uint8_t> buffer(outBufLen);
+				auto* pIpAdapterInfo = reinterpret_cast<PIP_ADAPTER_INFO>(buffer.data());
 				{
-					dwResult = GetAdaptersInfo(pIpAdapterInfo.get(), &outBufLen);
+					dwResult = GetAdaptersInfo(pIpAdapterInfo, &outBufLen);
 					if (dwResult == ERROR_SUCCESS)
 					{
-						for (auto* adapter = pIpAdapterInfo.get(); adapter; adapter = adapter->Next)
+						for (auto* adapter = pIpAdapterInfo; adapter; adapter = adapter->Next)
 						{
 							switch (adapter->Type)
 							{

--- a/src/Components/Modules/Auth.cpp
+++ b/src/Components/Modules/Auth.cpp
@@ -545,33 +545,36 @@ namespace Components
 			{
 				// Now allocate a structure of the required size.
 				PIP_ADAPTER_INFO pIpAdapterInfo = reinterpret_cast<PIP_ADAPTER_INFO>(malloc(outBufLen));
-				dwResult = GetAdaptersInfo(pIpAdapterInfo, &outBufLen);
-				if (dwResult == ERROR_SUCCESS)
+				if (pIpAdapterInfo)
 				{
-					while (pIpAdapterInfo)
+					PIP_ADAPTER_INFO pOriginal = pIpAdapterInfo;
+					dwResult = GetAdaptersInfo(pIpAdapterInfo, &outBufLen);
+					if (dwResult == ERROR_SUCCESS)
 					{
-						switch (pIpAdapterInfo->Type)
+						while (pIpAdapterInfo)
 						{
-							case IF_TYPE_IEEE80211:
-							case MIB_IF_TYPE_ETHERNET:
+							switch (pIpAdapterInfo->Type)
 							{
-
-								std::string macAddress{};
-								for (size_t i = 0; i < ARRAYSIZE(pIpAdapterInfo->Address); i++)
+								case IF_TYPE_IEEE80211:
+								case MIB_IF_TYPE_ETHERNET:
 								{
-									entropy += std::to_string(pIpAdapterInfo->Address[i]);
+
+									std::string macAddress{};
+									for (size_t i = 0; i < ARRAYSIZE(pIpAdapterInfo->Address); i++)
+									{
+										entropy += std::to_string(pIpAdapterInfo->Address[i]);
+									}
+
+									break;
 								}
-
-								break;
 							}
+
+							pIpAdapterInfo = pIpAdapterInfo->Next;
 						}
-
-						pIpAdapterInfo = pIpAdapterInfo->Next;
 					}
-				}
 
-				// Free before going next because clearly this is not working
-				free(pIpAdapterInfo);
+					free(pOriginal);
+				}
 			}
 
 		}

--- a/src/Components/Modules/Auth.cpp
+++ b/src/Components/Modules/Auth.cpp
@@ -544,36 +544,30 @@ namespace Components
 			if (dwResult == ERROR_BUFFER_OVERFLOW)  // This is what we're expecting
 			{
 				// Now allocate a structure of the required size.
-				PIP_ADAPTER_INFO pIpAdapterInfo = reinterpret_cast<PIP_ADAPTER_INFO>(malloc(outBufLen));
+				auto pIpAdapterInfo = std::unique_ptr<IP_ADAPTER_INFO, decltype(&free)>(
+					reinterpret_cast<PIP_ADAPTER_INFO>(malloc(outBufLen)), free);
 				if (pIpAdapterInfo)
 				{
-					PIP_ADAPTER_INFO pOriginal = pIpAdapterInfo;
-					dwResult = GetAdaptersInfo(pIpAdapterInfo, &outBufLen);
+					dwResult = GetAdaptersInfo(pIpAdapterInfo.get(), &outBufLen);
 					if (dwResult == ERROR_SUCCESS)
 					{
-						while (pIpAdapterInfo)
+						for (auto* adapter = pIpAdapterInfo.get(); adapter; adapter = adapter->Next)
 						{
-							switch (pIpAdapterInfo->Type)
+							switch (adapter->Type)
 							{
 								case IF_TYPE_IEEE80211:
 								case MIB_IF_TYPE_ETHERNET:
 								{
-
-									std::string macAddress{};
-									for (size_t i = 0; i < ARRAYSIZE(pIpAdapterInfo->Address); i++)
+									for (UINT i = 0; i < adapter->AddressLength; i++)
 									{
-										entropy += std::to_string(pIpAdapterInfo->Address[i]);
+										entropy += std::to_string(adapter->Address[i]);
 									}
 
 									break;
 								}
 							}
-
-							pIpAdapterInfo = pIpAdapterInfo->Next;
 						}
 					}
-
-					free(pOriginal);
 				}
 			}
 


### PR DESCRIPTION
The buffer allocated for `GetAdaptersInfo` wasn’t being freed properly. As the code walked the linked list, it overwrote the original pointer, so by the time `free()` was called it was operating on the traversed pointer instead of the original allocation.

This fix keeps the original pointer around and frees it after the traversal. It also adds a null check after `malloc` so we don’t pass an invalid buffer to `GetAdaptersInfo` if the allocation fails.