### PR TITLE
Allow servers to write r_specular and r_drawSun for fps boost GSC's

### DIFF
--- a/src/Components/Modules/Dvar.cpp
+++ b/src/Components/Modules/Dvar.cpp
@@ -444,10 +444,10 @@ namespace Components
 		Utils::Hook::Xor<std::uint32_t>(0x4D3786, Game::DVAR_ARCHIVE);
 
 		// remove all flags for r_drawSun
-		Utils::Hook::Set<std::uint8_t>(0x51a239, Game::DVAR_NONE);
+		Utils::Hook::Xor<std::uint8_t>(0x51A239, Game::DVAR_ARCHIVE);
 
 		// remove all flags for r_specular
-		Utils::Hook::Set<std::uint8_t>(0x519c39, Game::DVAR_NONE);
+		Utils::Hook::Xor<std::uint8_t>(0x519C39, Game::DVAR_ARCHIVE);
 
 		// remove write protection from fs_game
 		Utils::Hook::Xor<std::uint32_t>(0x6431EA, Game::DVAR_INIT);

--- a/src/Components/Modules/Dvar.cpp
+++ b/src/Components/Modules/Dvar.cpp
@@ -443,10 +443,10 @@ namespace Components
 		// remove archive flags for sv_hostname
 		Utils::Hook::Xor<std::uint32_t>(0x4D3786, Game::DVAR_ARCHIVE);
 
-		// remove all flags for r_drawSun
+		// remove archive flags for r_drawSun
 		Utils::Hook::Xor<std::uint8_t>(0x51A239, Game::DVAR_ARCHIVE);
 
-		// remove all flags for r_specular
+		// remove archive flags for r_specular
 		Utils::Hook::Xor<std::uint8_t>(0x519C39, Game::DVAR_ARCHIVE);
 
 		// remove write protection from fs_game

--- a/src/Components/Modules/Dvar.cpp
+++ b/src/Components/Modules/Dvar.cpp
@@ -443,6 +443,12 @@ namespace Components
 		// remove archive flags for sv_hostname
 		Utils::Hook::Xor<std::uint32_t>(0x4D3786, Game::DVAR_ARCHIVE);
 
+		// remove all flags for r_drawSun
+		Utils::Hook::Set<std::uint8_t>(0x51a239, Game::DVAR_NONE);
+
+		// remove all flags for r_specular
+		Utils::Hook::Set<std::uint8_t>(0x519c39, Game::DVAR_NONE);
+
 		// remove write protection from fs_game
 		Utils::Hook::Xor<std::uint32_t>(0x6431EA, Game::DVAR_INIT);
 


### PR DESCRIPTION
By removing flags from the offsets, we can allow serverside GSC's to write to the client's dvar using

```
self setClientDvar("r_specular",      1);
self setClientDvar("r_drawSun",       1);
```

which previously did not work due to their protection level.