### PR TITLE
fix(mods): preserve fs_game across CL_Disconnect during startup/devmap

### DIFF
--- a/src/Components/Modules/ModList.cpp
+++ b/src/Components/Modules/ModList.cpp
@@ -1,4 +1,5 @@
 #include "ModList.hpp"
+#include "Dedicated.hpp"
 #include "Events.hpp"
 #include "UIFeeder.hpp"
 
@@ -190,6 +191,13 @@ namespace Components
 
 			if (Components::Flags::HasFlag("disable-mod-unloading"))
 			{
+				return;
+			}
+
+			if (*Game::fs_gameDirVar != nullptr && *(*Game::fs_gameDirVar)->current.string != '\0')
+			{
+				// Preserve an explicitly selected mod during the startup/devmap CL_Disconnect
+				// path so the following FS_Startup keeps the same fs_game search path.
 				return;
 			}
 


### PR DESCRIPTION
Prevent ClearMods from running when a non-empty fs_game is already set. This avoids losing the active mod path during early CL_Disconnect calls, ensuring the subsequent FS_Startup rebuild keeps the correct search path.