### PR TITLE
ignore scrolling acceleration for joysticks

### DIFF
--- a/src/Components/Modules/Gamepad.cpp
+++ b/src/Components/Modules/Gamepad.cpp
@@ -1072,7 +1072,7 @@ namespace Components
 		{
 			if (key == scrollButton)
 			{
-				if (gamePadGlobal.scrollHoldKey != key)
+				if (key >= Game::K_DPAD_UP && key <= Game::K_DPAD_RIGHT && gamePadGlobal.scrollHoldKey != key)
 				{
 					gamePadGlobal.scrollHoldStartTime = time;
 					gamePadGlobal.scrollHoldKey = key;
@@ -1211,7 +1211,7 @@ namespace Components
 					if (time > gamePadGlobal.nextScrollTime)
 					{
 						auto delay = scrollDelayRest;
-						if (accelTime > 0 && scrollDelayRest > scrollDelayMin)
+						if (key >= Game::K_DPAD_UP && key <= Game::K_DPAD_RIGHT && accelTime > 0 && scrollDelayRest > scrollDelayMin)
 						{
 							const auto elapsed = static_cast<int>(time - gamePadGlobal.scrollHoldStartTime);
 							const auto t = std::min(elapsed, accelTime);


### PR DESCRIPTION
Restrict menu scroll acceleration timing to D-pad inputs only, since the logic introduced in 640c9a6f also applied to analog stick generated `K_APAD_*` navigation events, and caused held sticks to ramp into excessively fast menu scrolling.