### PR TITLE
Add view-independent ladder input

### DIFF
--- a/src/Components/Modules/PlayerMovement.cpp
+++ b/src/Components/Modules/PlayerMovement.cpp
@@ -318,24 +318,24 @@ namespace Components
 	{
 		__asm
 		{
-			push eax
+			// Fall back to stock if dvar is null or disabled
 			mov eax, BGLadderFixedInput
+			test eax, eax
+			jz stockPath
 			cmp byte ptr [eax + 0x10], 1
-			pop eax
+			jne stockPath
 
-			je classicMode
-
-			// Game's code: fld pml->forward[2]; fadd 0.25
-			fld dword ptr [ebp + 0x8]
-			fadd qword ptr ds:[0x70D1E8]
-			push 0x573FF8
-			ret
-
-		classicMode:
 			// Force v18 = 1.0 and skip the ±1 clamp
 			fld1
 			fstp dword ptr [esp + 0xC]
 			push 0x574034
+			ret
+
+		stockPath:
+			// Game's code: fld pml->forward[2]; fadd 0.25
+			fld dword ptr [ebp + 0x8]
+			fadd qword ptr ds:[0x70D1E8]
+			push 0x573FF8
 			ret
 		}
 	}
@@ -350,7 +350,7 @@ namespace Components
 			const float lx = ladderNormal[0];
 			const float ly = ladderNormal[1];
 			const float len2 = lx * lx + ly * ly;
-			const float invLen = (len2 > 0.0f) ? (1.0f / std::sqrt(len2)) : 1.0f;
+			const float invLen = (len2 > 0.0f) ? (1.0f / std::sqrtf(len2)) : 1.0f;
 			pmlRight[0] = -ly * invLen;
 			pmlRight[1] =  lx * invLen;
 			pmlRight[2] = 0.0f;

--- a/src/Components/Modules/PlayerMovement.cpp
+++ b/src/Components/Modules/PlayerMovement.cpp
@@ -405,7 +405,7 @@ namespace Components
 			false, Game::DVAR_CODINFO, "Disable player collision with out of bound barriers");
 
 		BGLadderFixedInput = Game::Dvar_RegisterBool("bg_ladderFixedInput",
-			false, Game::DVAR_CODINFO, "Make ladder climb and strafe independent of view angle");
+			false, Game::DVAR_SYSTEMINFO, "Make ladder climb and strafe independent of view angle");
 	}
 
 	PlayerMovement::PlayerMovement()

--- a/src/Components/Modules/PlayerMovement.cpp
+++ b/src/Components/Modules/PlayerMovement.cpp
@@ -22,6 +22,7 @@ namespace Components
 	const Game::dvar_t* PlayerMovement::PlayerDuckedSpeedScale;
 	const Game::dvar_t* PlayerMovement::PlayerProneSpeedScale;
 	const Game::dvar_t* PlayerMovement::BGDisableBarrierClips;
+	const Game::dvar_t* PlayerMovement::BGLadderFixedInput;
 
 	void PlayerMovement::PM_PlayerTraceStub(Game::pmove_s* pm, Game::trace_t* results, const float* start, const float* end, Game::Bounds* bounds, int passEntityNum, int contentMask)
 	{
@@ -310,6 +311,55 @@ namespace Components
 		}
 	}
 
+	// Replaces PM_LadderMove's pitch-scaled climb multiplier
+	// (v18 = clamp((forward[2] + 0.25) * 2.5, -1, +1)) at 0x573FEF with a
+	// constant 1.0 so vertical wishvel becomes 0.5 * cmdScale * forwardmove.
+	__declspec(naked) void PlayerMovement::PM_LadderMove_PitchStub()
+	{
+		__asm
+		{
+			push eax
+			mov eax, BGLadderFixedInput
+			cmp byte ptr [eax + 0x10], 1
+			pop eax
+
+			je classicMode
+
+			// Game's code: fld pml->forward[2]; fadd 0.25
+			fld dword ptr [ebp + 0x8]
+			fadd qword ptr ds:[0x70D1E8]
+			push 0x573FF8
+			ret
+
+		classicMode:
+			// Force v18 = 1.0 and skip the ±1 clamp
+			fld1
+			fstp dword ptr [esp + 0xC]
+			push 0x574034
+			ret
+		}
+	}
+
+	// Replaces the camera-relative right-vector projection inside PM_LadderMove
+	// (Vec3ProjectOnPlane at 0x4C3130, single call site at 0x574061) with the
+	// ladder-locked form: pml->right = (-Ly, Lx, 0) / |L_xy|.
+	float* PlayerMovement::PM_LadderMove_RightVector_Hk(float* source, const float* ladderNormal, float* pmlRight)
+	{
+		if (BGLadderFixedInput && BGLadderFixedInput->current.enabled)
+		{
+			const float lx = ladderNormal[0];
+			const float ly = ladderNormal[1];
+			const float len2 = lx * lx + ly * ly;
+			const float invLen = (len2 > 0.0f) ? (1.0f / std::sqrt(len2)) : 1.0f;
+			pmlRight[0] = -ly * invLen;
+			pmlRight[1] =  lx * invLen;
+			pmlRight[2] = 0.0f;
+			return source; // match the original helper's return-first-arg contract
+		}
+
+		return Utils::Hook::Call<float*(float*, const float*, float*)>(0x4C3130)(source, ladderNormal, pmlRight);
+	}
+
 	void PlayerMovement::RegisterMovementDvars()
 	{
 		PlayerDuckedSpeedScale = Game::Dvar_RegisterFloat("player_duckedSpeedScale",
@@ -353,6 +403,9 @@ namespace Components
 
 		BGDisableBarrierClips = Game::Dvar_RegisterBool("bg_disableBarrierClips",
 			false, Game::DVAR_CODINFO, "Disable player collision with out of bound barriers");
+
+		BGLadderFixedInput = Game::Dvar_RegisterBool("bg_ladderFixedInput",
+			false, Game::DVAR_CODINFO, "Make ladder climb and strafe independent of view angle");
 	}
 
 	PlayerMovement::PlayerMovement()
@@ -414,9 +467,13 @@ namespace Components
 		Utils::Hook(0x570020, PM_CrashLand_Stub, HOOK_CALL).install()->quick(); // Vec3Scale
 		Utils::Hook(0x4E9889, Jump_Check_Stub, HOOK_JUMP).install()->quick();
 
-		// Disable player collision with out of bound barriers 
+		// Disable player collision with out of bound barriers
 		Utils::Hook(0x4CFF5C, PmoveSingle_Stub, HOOK_CALL).install()->quick(); 			// single PmoveSingle call inside Pmove
 		Utils::Hook(0x574AF4, PM_CheckLadderMove_Stub, HOOK_CALL).install()->quick(); 	// single PM_CheckLadderMove call inside PmoveSingle
+
+		// View-independent ladder controls (opt-in via bg_ladderFixedInput)
+		Utils::Hook(0x573FEF, PM_LadderMove_PitchStub, HOOK_JUMP).install()->quick();       // pitch-scaled climb rate block
+		Utils::Hook(0x574061, PM_LadderMove_RightVector_Hk, HOOK_CALL).install()->quick();  // camera-relative right-vector projection
 
 		GSC::Script::AddMethod("IsSprinting", GScr_IsSprinting);
 

--- a/src/Components/Modules/PlayerMovement.hpp
+++ b/src/Components/Modules/PlayerMovement.hpp
@@ -27,6 +27,7 @@ namespace Components
 		static const Game::dvar_t* PlayerDuckedSpeedScale;
 		static const Game::dvar_t* PlayerProneSpeedScale;
 		static const Game::dvar_t* BGDisableBarrierClips;
+		static const Game::dvar_t* BGLadderFixedInput;
 
 		static void PM_PlayerTraceStub(Game::pmove_s* pm, Game::trace_t* results, const float* start, const float* end, Game::Bounds* bounds, int passEntityNum, int contentMask);
 		static void PM_PlayerDuckedSpeedScaleStub();
@@ -58,5 +59,8 @@ namespace Components
 
 		static void PmoveSingle_Stub(Game::pmove_s* pm);
 		static void PM_CheckLadderMove_Stub(Game::pmove_s* pm, Game::pml_t* pml);
+
+		static void PM_LadderMove_PitchStub();
+		static float* PM_LadderMove_RightVector_Hk(float* source, const float* ladderNormal, float* pmlRight);
 	};
 }


### PR DESCRIPTION
## Summary
**What does this PR do?**
Adds one opt-in dvar to `PlayerMovement` that restores the console ladder feel on PC: climb rate and sideways strafe become independent of view angle. Defaults off, so stock PC behavior is preserved unless a server or player explicitly opts in.

**Related Issues:**
None.

## Technical Details
**How does this PR change IW4x's behavior?**

One new dvar, bool, default `false`, `DVAR_CODINFO`:

| Dvar | Effect |
|---|---|
| `bg_ladderFixedInput` | Replace PC's view-coupled ladder math with the console (specifically Xbox 360) form. Climb rate becomes a constant `0.5 * cmdScale * forwardmove` regardless of view pitch (vs PC's pitch-scaled variant that drops to `0.3125x` at level look and reverses past ~14.5 degrees of pitch-down). Sideways strafe direction is locked to the ladder and computed from `vLadderVec` alone (vs PC's camera-right projected onto the ladder plane, which loses magnitude as yaw deviates from facing the ladder and can reverse near the `bg_ladder_yawcap` limit). |

Implementation is two surgical runtime hooks into `PM_LadderMove`:

- `PM_LadderMove_PitchStub` - naked asm stub in `PM_LadderMove` that replaces the pitch-scaled climb multiplier with a constant when the dvar is on, so vertical climb rate depends only on `forwardmove` and `cmdScale`. Falls through to the stock multiplier when off.
- `PM_LadderMove_RightVector_Hk` - C++ hook on the single camera-right projection call inside `PM_LadderMove` that writes a ladder-locked sideways direction derived from `vLadderVec` when the dvar is on. Falls through to the stock helper when off.

Both hooks fall back to byte-equivalent vanilla behavior when the dvar is off. The math has been verified against an Xbox 360 build of the game.

**Breaking changes:**
None. All new behavior is dvar-gated and defaults off.

**Performance impact:**
Negligible. Each hook adds a dvar check plus branch on the fast path. The C++ right-vector hook falls through to `Utils::Hook::Call<>(0x4C3130)` when the dvar is off.

## Testing
**How has this been tested?**
- [x] Manual testing - [Video](https://youtu.be/Fb4xFtbGMKs)

**Test environment:**
- OS: Windows 11

**Test results:**
- Dvar off: climb rate and strafe match vanilla PC behavior - climb varies with view pitch, strafe magnitude varies with view yaw, strafe direction reverses past 90 degrees off the ladder face. Byte-equivalent to stock.
- Dvar on: climb rate is constant regardless of view pitch (can climb while looking straight down); strafe direction is locked to the ladder and runs at full speed throughout the entire `bg_ladder_yawcap` range, never stalling or reversing.

## Code Quality
**Code review checklist:**
- [x] Code follows the [coding conventions](https://github.com/iw4x/iw4x-client/blob/master/CODESTYLE.md)
- [x] Self-review of code completed
- [x] Code is properly commented
- [x] No debug code or temporary changes left in
- [x] No unnecessary formatting changes
- [x] Commit messages are clear and descriptive

**Security considerations:**
- [x] No hardcoded credentials or sensitive data
- [x] Input validation implemented where necessary
- [x] No obvious security vulnerabilities introduced

## Compatibility
**Backward compatibility:**
- [x] This change is backward compatible

**Mod compatibility:**
- [x] No impact on existing mods

## Final Checklist
- [x] PR focuses on a single fix or feature
- [x] All related issues are mentioned
- [x] Coding conventions followed
- [x] Number of commits minimized (single commit)
- [x] PR title and description are clear and descriptive
- [x] All tests pass locally
- [x] Ready for review