### PR TITLE
Add console-style sprint input

### DIFF
--- a/src/Components/Modules/PlayerMovement.cpp
+++ b/src/Components/Modules/PlayerMovement.cpp
@@ -23,6 +23,7 @@ namespace Components
 	const Game::dvar_t* PlayerMovement::PlayerProneSpeedScale;
 	const Game::dvar_t* PlayerMovement::BGDisableBarrierClips;
 	const Game::dvar_t* PlayerMovement::BGLadderFixedInput;
+	const Game::dvar_t* PlayerMovement::BGSprintIgnoreRepress;
 
 	void PlayerMovement::PM_PlayerTraceStub(Game::pmove_s* pm, Game::trace_t* results, const float* start, const float* end, Game::Bounds* bounds, int passEntityNum, int contentMask)
 	{
@@ -360,6 +361,38 @@ namespace Components
 		return Utils::Hook::Call<float*(float*, const float*, float*)>(0x4C3130)(source, ladderNormal, pmlRight);
 	}
 
+	// Disables PM_UpdateSprint's PC-only sprint re-press cancel when enabled.
+	// Otherwise keeps the original behavior.
+	__declspec(naked) void PlayerMovement::PM_UpdateSprint_RepressCallStub()
+	{
+		__asm
+		{
+			push eax
+			pushfd
+
+			mov eax, BGSprintIgnoreRepress
+			test eax, eax
+			jz stockPath                     // null during early init
+			cmp byte ptr [eax + 0x10], 1     // dvar_t.current.enabled
+			jne stockPath
+
+			// Enabled: skip end-sprint call AND sprintButtonUpRequired write.
+			popfd
+			pop eax
+			push 0x56EF64
+			ret
+
+		stockPath:
+			popfd
+			pop eax
+			mov ecx, ebp
+			mov eax, edi
+			push 0x56EF5E
+			push 0x56ECD0
+			ret
+		}
+	}
+
 	void PlayerMovement::RegisterMovementDvars()
 	{
 		PlayerDuckedSpeedScale = Game::Dvar_RegisterFloat("player_duckedSpeedScale",
@@ -406,6 +439,10 @@ namespace Components
 
 		BGLadderFixedInput = Game::Dvar_RegisterBool("bg_ladderFixedInput",
 			false, Game::DVAR_SYSTEMINFO, "Make ladder climb and strafe independent of view angle");
+
+		BGSprintIgnoreRepress = Game::Dvar_RegisterBool("bg_sprintIgnoreRepress",
+			false, Game::DVAR_SYSTEMINFO,
+			"Ignore sprint-key re-presses while already sprinting (matches console behaviour)");
 	}
 
 	PlayerMovement::PlayerMovement()
@@ -474,6 +511,9 @@ namespace Components
 		// View-independent ladder controls (opt-in via bg_ladderFixedInput)
 		Utils::Hook(0x573FEF, PM_LadderMove_PitchStub, HOOK_JUMP).install()->quick();       // pitch-scaled climb rate block
 		Utils::Hook(0x574061, PM_LadderMove_RightVector_Hk, HOOK_CALL).install()->quick();  // camera-relative right-vector projection
+
+		// Console-style sprint hold (opt-in via bg_sprintIgnoreRepress)
+		Utils::Hook(0x56EF59, PM_UpdateSprint_RepressCallStub, HOOK_JUMP).install()->quick();
 
 		GSC::Script::AddMethod("IsSprinting", GScr_IsSprinting);
 

--- a/src/Components/Modules/PlayerMovement.hpp
+++ b/src/Components/Modules/PlayerMovement.hpp
@@ -28,6 +28,7 @@ namespace Components
 		static const Game::dvar_t* PlayerProneSpeedScale;
 		static const Game::dvar_t* BGDisableBarrierClips;
 		static const Game::dvar_t* BGLadderFixedInput;
+		static const Game::dvar_t* BGSprintIgnoreRepress;
 
 		static void PM_PlayerTraceStub(Game::pmove_s* pm, Game::trace_t* results, const float* start, const float* end, Game::Bounds* bounds, int passEntityNum, int contentMask);
 		static void PM_PlayerDuckedSpeedScaleStub();
@@ -62,5 +63,7 @@ namespace Components
 
 		static void PM_LadderMove_PitchStub();
 		static float* PM_LadderMove_RightVector_Hk(float* source, const float* ladderNormal, float* pmlRight);
+
+		static void PM_UpdateSprint_RepressCallStub();
 	};
 }


### PR DESCRIPTION
## Summary
**What does this PR do?**
Adds one opt-in dvar to `PlayerMovement` that restores console sprint behavior on PC: re-pressing the sprint key while already sprinting is ignored instead of cancelling the sprint. Defaults off, so the original PC behavior is preserved unless the dvar is enabled.

**Related Issues:**
None.

## Technical Details
**How does this PR change IW4x's behavior?**

One new dvar, bool, default `false`, `DVAR_SYSTEMINFO`:

| Dvar | Effect |
|---|---|
| `bg_sprintIgnoreRepress` | Suppresses the PC-only rising-edge sprint cancel inside `PM_UpdateSprint`. While sprinting, if `PM_SprintEndingButtons` returns false and the sprint key transitions from released to held (`(oldcmd.buttons & 2) == 0 && (cmd.buttons & 2) != 0`), stock PC ends the sprint and sets `sprintState.sprintButtonUpRequired = 1`. On Xbox 360 there is no such branch; the re-press is ignored. With the dvar on, mid-sprint re-presses leave the sprint state unchanged. |

Implementation is one surgical runtime hook inside `PM_UpdateSprint`:

- `PM_UpdateSprint_RepressCallStub` - When the dvar is on, the stub skips both the end-sprint call and the subsequent `sprintButtonUpRequired = 1` write by resuming at `0x56EF64`. When the dvar is off, the stub reconstructs the original call and resumes at `0x56EF5E`, preserving the original PC behavior.

The divergence has been verified against an Xbox 360 build of the game.

**Breaking changes:**
None. All new behavior is dvar-gated and defaults off.

**Performance impact:**
Negligible. The hook adds a dvar null-check and single-byte compare on a path that is only reached on a sprint-key re-press while already sprinting.

## Testing
**How has this been tested?**
- [x] Manual testing - [Video](https://youtu.be/CRZgZu13Iek)

**Test environment:**
- OS: Windows 11

**Test results:**
- Dvar off: re-pressing the sprint key during an active sprint ends the sprint immediately and sets `ps->sprintState.sprintButtonUpRequired = 1`, requiring a button release before sprint can start again. Matches the original PC behavior.
- Dvar on: re-pressing the sprint key during an active sprint has no effect on the sprint state. `PMF_SPRINTING` stays set, `PM_UpdateSprint` does not set `sprintButtonUpRequired` through this path, and sprint continues until one of the normal end conditions (ADS, duck, prone, etc.) fires naturally.

## Code Quality
**Code review checklist:**
- [x] Code follows the [coding conventions](https://github.com/iw4x/iw4x-client/blob/master/CODESTYLE.md)
- [x] Self-review of code completed
- [x] Code is properly commented
- [x] No debug code or temporary changes left in
- [x] No unnecessary formatting changes
- [x] Commit messages are clear and descriptive

**Security considerations:**
- [x] No hardcoded credentials or sensitive data
- [x] Input validation implemented where necessary
- [x] No obvious security vulnerabilities introduced

## Compatibility
**Backward compatibility:**
- [x] This change is backward compatible

**Mod compatibility:**
- [x] No impact on existing mods

## Final Checklist
- [x] PR focuses on a single fix or feature
- [x] All related issues are mentioned
- [x] Coding conventions followed
- [x] Number of commits minimized (single commit)
- [x] PR title and description are clear and descriptive
- [x] All tests pass locally
- [x] Ready for review