### PR TITLE
Fixes #352

### DIFF
--- a/src/Components/Modules/Maps.cpp
+++ b/src/Components/Modules/Maps.cpp
@@ -252,13 +252,20 @@ namespace Components
 
 		if (type == Game::XAssetType::ASSET_TYPE_MAP_ENTS)
 		{
-			if (Flags::HasFlag("dump"))
+			std::string entitiesFilename = name;
+
+			if (entitiesFilename.starts_with("maps/mp/maps/mp") && entitiesFilename.ends_with(".d3dbsp.d3dbsp"))
 			{
-				Utils::IO::WriteFile(Utils::String::VA("raw/%s.ents", name.data()), asset.mapEnts->entityString, true);
+				// As of 2026 some MW3 maps have been built with this strange clipmap name, likely an artifact of IW5xport.
+				// It is not problematic in itself but it breaks overrides via ents files
+				// We can hotfix it here until one day where we re-build and re-ship every MW3 maps with additional fixes
+				const auto prefixLength = "maps/mp/"s.size();
+				const auto suffixLength = ".d3dbsp"s.size();
+				entitiesFilename = entitiesFilename.substr(prefixLength, entitiesFilename.size() - prefixLength - suffixLength);
 			}
 
 			static std::string mapEntities;
-			FileSystem::File ents(name + ".ents", Game::FS_THREAD_DATABASE);
+			FileSystem::File ents(entitiesFilename + ".ents", Game::FS_THREAD_DATABASE);
 			if (ents.exists())
 			{
 				mapEntities = ents.getBuffer();


### PR DESCRIPTION
The real issue comes with MW3 maps which have a strange, mangled clipmap name. Fixing it requires rebuilding, testing and redeploying each of the 9 MW3 maps. Right now this patches it until we can find the time to rebuild all of them (and maybe find the bug in iw5xport that is causing this?)

Also removed old "dump" function lying around here, no longer necessary because IW4OF can dump the clipmap & ents too