### PR TITLE
fix: disable menu runtime state cloning

### DIFF
--- a/src/Components/Modules/Menus.cpp
+++ b/src/Components/Modules/Menus.cpp
@@ -38,29 +38,6 @@ namespace Components
 
 	Utils::Memory::Allocator Menus::Allocator;
 
-	using MenuDynamicCloneHandler = int(__cdecl*)(Game::XAssetHeader, Game::XAssetHeader, Game::DB_CloneType);
-	const auto DB_DynamicCloneMenu = reinterpret_cast<MenuDynamicCloneHandler>(0x5BAD10);
-
-	// Preserve runtime menu state during replacement, but do not copy item state by index
-	// when the old and new menu layouts differ.
-	int DynamicCloneMenu(const Game::XAssetHeader newHeader, const Game::XAssetHeader existingHeader, const Game::DB_CloneType cloneType)
-	{
-		auto* newMenu = newHeader.menu;
-		auto* existingMenu = existingHeader.menu;
-		if (!newMenu || !existingMenu || newMenu->itemCount == existingMenu->itemCount)
-		{
-			return DB_DynamicCloneMenu(newHeader, existingHeader, cloneType);
-		}
-
-		if (cloneType != Game::DB_CLONE_DEFAULT && cloneType != Game::DB_CLONE_NORMAL_FROM_DEFAULT)
-		{
-			newMenu->cursorItem[0] = existingMenu->cursorItem[0];
-			newMenu->window.dynamicFlags[0] = existingMenu->window.dynamicFlags[0];
-		}
-
-		return 1;
-	}
-
 	Game::KeywordHashEntry<Game::menuDef_t, 128, 3523>** menuParseKeywordHash;
 
 	template <int HASH_COUNT, int HASH_SEED>
@@ -1537,8 +1514,11 @@ namespace Components
 
 		if (Dedicated::IsEnabled()) return;
 
-		auto* dynamicCloneHandlers = reinterpret_cast<MenuDynamicCloneHandler*>(0x799A08);
-		Utils::Hook::Set(&dynamicCloneHandlers[Game::ASSET_TYPE_MENU], DynamicCloneMenu);
+		// The stock ASSET_TYPE_MENU clone handler copies runtime state from the existing menu to its
+		// replacement, assuming both menus have identical item layouts. Disable it to prevent state
+		// from being copied between unrelated items when the layouts differ.
+		Utils::Hook::Set<Game::DB_DynamicCloneXAssetHandler_t>(
+			&Game::DB_DynamicCloneXAssetHandler[Game::ASSET_TYPE_MENU], nullptr);
 
 		Menus::InitializeSupportingData();
 

--- a/src/Components/Modules/Menus.cpp
+++ b/src/Components/Modules/Menus.cpp
@@ -38,6 +38,29 @@ namespace Components
 
 	Utils::Memory::Allocator Menus::Allocator;
 
+	using MenuDynamicCloneHandler = int(__cdecl*)(Game::XAssetHeader, Game::XAssetHeader, Game::DB_CloneType);
+	const auto DB_DynamicCloneMenu = reinterpret_cast<MenuDynamicCloneHandler>(0x5BAD10);
+
+	// Preserve runtime menu state during replacement, but do not copy item state by index
+	// when the old and new menu layouts differ.
+	int DynamicCloneMenu(const Game::XAssetHeader newHeader, const Game::XAssetHeader existingHeader, const Game::DB_CloneType cloneType)
+	{
+		auto* newMenu = newHeader.menu;
+		auto* existingMenu = existingHeader.menu;
+		if (!newMenu || !existingMenu || newMenu->itemCount == existingMenu->itemCount)
+		{
+			return DB_DynamicCloneMenu(newHeader, existingHeader, cloneType);
+		}
+
+		if (cloneType != Game::DB_CLONE_DEFAULT && cloneType != Game::DB_CLONE_NORMAL_FROM_DEFAULT)
+		{
+			newMenu->cursorItem[0] = existingMenu->cursorItem[0];
+			newMenu->window.dynamicFlags[0] = existingMenu->window.dynamicFlags[0];
+		}
+
+		return 1;
+	}
+
 	Game::KeywordHashEntry<Game::menuDef_t, 128, 3523>** menuParseKeywordHash;
 
 	template <int HASH_COUNT, int HASH_SEED>
@@ -1513,6 +1536,9 @@ namespace Components
 		}
 
 		if (Dedicated::IsEnabled()) return;
+
+		auto* dynamicCloneHandlers = reinterpret_cast<MenuDynamicCloneHandler*>(0x799A08);
+		Utils::Hook::Set(&dynamicCloneHandlers[Game::ASSET_TYPE_MENU], DynamicCloneMenu);
 
 		Menus::InitializeSupportingData();
 

--- a/src/Game/Database.cpp
+++ b/src/Game/Database.cpp
@@ -23,6 +23,7 @@ namespace Game
 	DB_GetXAssetNameHandler_t* DB_GetXAssetNameHandlers = reinterpret_cast<DB_GetXAssetNameHandler_t*>(0x799328);
 	DB_GetXAssetSizeHandler_t* DB_GetXAssetSizeHandlers = reinterpret_cast<DB_GetXAssetSizeHandler_t*>(0x799488);
 	DB_ReleaseXAssetHandler_t* DB_ReleaseXAssetHandlers = reinterpret_cast<DB_ReleaseXAssetHandler_t*>(0x799AB8);
+	DB_DynamicCloneXAssetHandler_t* DB_DynamicCloneXAssetHandler = reinterpret_cast<DB_DynamicCloneXAssetHandler_t*>(0x799A08);
 
 	XAssetHeader* DB_XAssetPool = reinterpret_cast<XAssetHeader*>(0x7998A8);
 	unsigned int* g_poolSize = reinterpret_cast<unsigned int*>(0x7995E8);

--- a/src/Game/Database.hpp
+++ b/src/Game/Database.hpp
@@ -90,6 +90,9 @@ namespace Game
 	typedef void(*DB_ReleaseXAssetHandler_t)(XAssetHeader header);
 	extern DB_ReleaseXAssetHandler_t* DB_ReleaseXAssetHandlers;
 
+	typedef int(*DB_DynamicCloneXAssetHandler_t)(XAssetHeader, XAssetHeader, DB_CloneType);
+	extern DB_DynamicCloneXAssetHandler_t* DB_DynamicCloneXAssetHandler;
+
 	typedef void(*RMesg_SendMessages_t)();
 	extern RMesg_SendMessages_t RMesg_SendMessages;
 

--- a/src/Game/Structs.hpp
+++ b/src/Game/Structs.hpp
@@ -100,6 +100,14 @@ namespace Game
 		ASSET_TYPE_INVALID = -1,
 	};
 
+	enum DB_CloneType : int
+	{
+		DB_CLONE_DEFAULT = 0x0,
+		DB_CLONE_NORMAL = 0x1,
+		DB_CLONE_SWAP = 0x2,
+		DB_CLONE_NORMAL_FROM_DEFAULT = 0x3,
+	};
+
 	enum GfxWarningType
 	{
 		R_WARN_FRONTEND_ENT_LIMIT = 0x0,


### PR DESCRIPTION
## Summary

While investigating [OpenAssetTools issue #78](https://github.com/Laupetin/OpenAssetTools/issues/78#issuecomment-5008618232), I traced the IW4x Options menu glow to the game's fastfile menu replacement path.

`DB_DynamicCloneMenu` copies runtime state from the existing menu to its replacement by item index, assuming identical layouts. The stock `pc_options_video` has 28 items while the IW4x replacement has 52, causing unrelated items to inherit state.

This disables `DB_DynamicCloneXAssetHandler[ASSET_TYPE_MENU]`. Menus are still replaced normally without copying stale runtime state.

## Verification

- Loaded an OAT-built `iw4x_code_post_gfx_mp.ff`
- Confirmed the Options menu glow was gone
- Confirmed menu navigation still worked

The initial targeted fix and the final simplified approach are kept as separate commits for review.