### PR TITLE
feat(gsc): add `SetBrushModel` entity method

### DIFF
--- a/src/Components/Modules/GSC/Entity.cpp
+++ b/src/Components/Modules/GSC/Entity.cpp
@@ -1,0 +1,38 @@
+#include "Entity.hpp"
+#include "Script.hpp"
+
+namespace Components::GSC
+{
+	void Entity::AddScriptMethods()
+	{
+		Script::AddMethod("SetBrushModel", [](const Game::scr_entref_t entref) // gsc: <entity> SetBrushModel(<index>)
+		{
+			if (Game::Scr_GetNumParam() != 1)
+			{
+				Game::Scr_Error("usage: <entity> SetBrushModel( <index> )\n");
+				return;
+			}
+
+			auto* ent = Game::GetEntity(entref);
+			const auto index = Game::Scr_GetInt(0);
+
+			if (index < 0 || static_cast<unsigned int>(index) >= Game::cm->numSubModels)
+			{
+				Game::Scr_ParamError(0, "brush model index out of range");
+				return;
+			}
+
+			Game::SV_UnlinkEntity(ent);
+			ent->s.index.brushModel = index;
+			ent->r.modelType = Game::MODELTYPE_BRUSH;
+
+			Game::SV_SetBrushModel(ent);
+			Game::SV_LinkEntity(ent);
+		});
+	}
+
+	Entity::Entity()
+	{
+		AddScriptMethods();
+	}
+}

--- a/src/Components/Modules/GSC/Entity.hpp
+++ b/src/Components/Modules/GSC/Entity.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace Components::GSC
+{
+	class Entity : public Component
+	{
+	public:
+		Entity();
+
+	private:
+		static void AddScriptMethods();
+	};
+}

--- a/src/Components/Modules/GSC/GSC.cpp
+++ b/src/Components/Modules/GSC/GSC.cpp
@@ -1,4 +1,5 @@
 #include "GSC.hpp"
+#include "Entity.hpp"
 #include "Field.hpp"
 #include "Int64.hpp"
 #include "IO.hpp"
@@ -14,6 +15,7 @@ namespace Components::GSC
 {
 	GSC::GSC()
 	{
+		Loader::Register(new Entity());
 		Loader::Register(new Field());
 		Loader::Register(new Int64());
 		Loader::Register(new IO());

--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -316,6 +316,7 @@ namespace Game
 
 	SpawnVar* spawnVars = reinterpret_cast<SpawnVar*>(0x1A83DE8);
 	MapEnts** marMapEntsPtr = reinterpret_cast<MapEnts**>(0x112AD34);
+	clipMap_t* cm = reinterpret_cast<clipMap_t*>(0x1AA6480);
 
 	IDirect3D9** d3d9 = reinterpret_cast<IDirect3D9**>(0x66DEF84);
 	IDirect3DDevice9** dx_ptr = reinterpret_cast<IDirect3DDevice9**>(0x66DEF88);

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -692,6 +692,7 @@ namespace Game
 
 	extern SpawnVar* spawnVars;
 	extern MapEnts** marMapEntsPtr;
+	extern clipMap_t* cm;
 
 	extern IDirect3D9** d3d9;
 	extern IDirect3DDevice9** dx_ptr;

--- a/src/Game/Server.cpp
+++ b/src/Game/Server.cpp
@@ -5,6 +5,9 @@ namespace Game
 	SV_AddTestClient_t SV_AddTestClient = SV_AddTestClient_t(0x48AD30);
 	SV_IsTestClient_t SV_IsTestClient = SV_IsTestClient_t(0x4D6E40);
 	SV_GameClientNum_Score_t SV_GameClientNum_Score = SV_GameClientNum_Score_t(0x469AC0);
+	SV_SetBrushModel_t SV_SetBrushModel = SV_SetBrushModel_t(0x466830);
+	SV_UnlinkEntity_t SV_UnlinkEntity = SV_UnlinkEntity_t(0x504210);
+	SV_LinkEntity_t SV_LinkEntity = SV_LinkEntity_t(0x4E0880);
 	SV_GameSendServerCommand_t SV_GameSendServerCommand = SV_GameSendServerCommand_t(0x4BC3A0);
 	SV_SendServerCommand_t SV_SendServerCommand = SV_SendServerCommand_t(0x4255A0);
 	SV_Cmd_TokenizeString_t SV_Cmd_TokenizeString = SV_Cmd_TokenizeString_t(0x4B5780);

--- a/src/Game/Server.hpp
+++ b/src/Game/Server.hpp
@@ -11,6 +11,15 @@ namespace Game
 	typedef int(*SV_GameClientNum_Score_t)(int clientID);
 	extern SV_GameClientNum_Score_t SV_GameClientNum_Score;
 
+	typedef int(*SV_SetBrushModel_t)(gentity_s* ent);
+	extern SV_SetBrushModel_t SV_SetBrushModel;
+
+	typedef void(*SV_UnlinkEntity_t)(gentity_s* ent);
+	extern SV_UnlinkEntity_t SV_UnlinkEntity;
+
+	typedef void(*SV_LinkEntity_t)(gentity_s* ent);
+	extern SV_LinkEntity_t SV_LinkEntity;
+
 	typedef void(*SV_GameSendServerCommand_t)(int clientNum, svscmd_type type, const char* text);
 	extern SV_GameSendServerCommand_t SV_GameSendServerCommand;
 

--- a/src/Game/Structs.hpp
+++ b/src/Game/Structs.hpp
@@ -7506,10 +7506,19 @@ namespace Game
 		unsigned __int16 infoIndex;
 	};
 
+	enum ModelType : unsigned char
+	{
+		MODELTYPE_CAPSULE = 0x0,
+		MODELTYPE_CYLINDER = 0x1,
+		MODELTYPE_DISK = 0x2,
+		MODELTYPE_TRIGGER = 0x3,
+		MODELTYPE_BRUSH = 0x4,
+	};
+
 	struct entityShared_t
 	{
 		char isLinked;
-		char modelType;
+		ModelType modelType;
 		char svFlags;
 		char isInUse;
 		Bounds box;


### PR DESCRIPTION
Adds a new server-side GSC entity method:

```gsc
<entity> SetBrushModel( <index> );
```

This allows scripts to assign an existing map brush model to an entity at runtime. It is a server-side-only modification and does not require connected clients to have the newest client version.

Brush models are limited to the collision models already included in the loaded map BSP. Brush-model references in the map-ents entity string use the format `*N`, where `N` is an index into the clipmap's `cmodels` array. For example:

```text
"model" "*37"
```

For example, `mp_terminal` contains the following search-and-destroy bomb brush model:

```text
{
"script_gameobjectname" "bombzone"
"classname" "script_brushmodel"
"origin" "2081 4587 220"
"model" "*37"
}
{
"gndLt" "5c57558e01"
"ltOrigin" "2082.22 4586.62 220.123"
"classname" "script_model"
"model" "com_bomb_objective"
"angles" "0 3.18772e-006 0"
"origin" "2080.8 4586.5 190.1"
"script_exploder" "pf3167_1"
"script_gameobjectname" "bombzone"
"spawnflags" "4"
"targetname" "pf3167_auto1"
"target" "pf3167_auto2"
}
```

During map loading, these definitions are parsed and their entities are created automatically. `SetBrushModel` makes it possible to instantiate the same brush model dynamically during a match:

```gsc
brush = spawn( "script_model", origin );
brush SetBrushModel( 37 );
```

The resulting entity can be positioned, rotated, linked, and manipulated like other script entities while retaining the brush model's collision.

Brush model index `0` is a special case representing the world model, as demonstrated in the attached video. The contents of other indices depend on the map and must be inspected or tested individually.


https://github.com/user-attachments/assets/b67d99d3-46a4-465c-b8c9-c69cba5b3b93

