### PR TITLE
Fix thermal scope exploit

### DIFF
--- a/src/Components/Modules/Dvar.cpp
+++ b/src/Components/Modules/Dvar.cpp
@@ -416,8 +416,8 @@ namespace Components
 		// un-cheat cg_drawGun
 		Utils::Hook::Set<std::uint8_t>(0x4F8DC6, Game::DVAR_NONE);
 
-		// un-cheat cg_draw2D
-		Utils::Hook::Set<std::uint8_t>(0x4F8EEE, Game::DVAR_NONE);
+		// re-cheat cg_draw2D to prevent stripping the thermal scope's mask overlay via cg_draw2D 0
+		Utils::Hook::Or<std::uint8_t>(0x4F8EEE, Game::DVAR_CHEAT);
 
 		// un-cheat cg_overheadNamesFarScale
 		Utils::Hook::Set<std::uint8_t>(0x4FA7C4, Game::DVAR_NONE);

--- a/src/Components/Modules/Weapon.hpp
+++ b/src/Components/Modules/Weapon.hpp
@@ -20,7 +20,6 @@ namespace Components
 		static const Game::dvar_t* BGWeaponOffHandFix;
 		static const Game::dvar_t* CGRecoilMultiplier;
 
-
 		static Game::WeaponCompleteDef* LoadWeaponCompleteDef(const char* name);
 		static void PatchLimit();
 		static void* LoadNoneWeaponHook();


### PR DESCRIPTION
Makes sure `cg_draw2d` is properly locked as DVAR_CHEAT to resolve issue noted in https://github.com/iw4x/iw4x-client/issues/349

**Reproduction done (before fix):**
1. Create a class with a thermal scope
2. Start a private match
3. Choose the class with thermal
4. Open Console and type `cg_draw2D 0`
5. See the 2D hud elements disappear
6. ADS your gun and see the 2D scope is also gone

**Testing Done (after fix)**

On `Release` build:

1. Create a class with a thermal scope
2. Start a private match
3. Choose the class with thermal
4. Open Console and type `cg_draw2D 0`
5. See the 2D hud elements no longer disappear
6. ADS your gun and see the 2D scope is still present

Regression Testing:
1. Load into a devmap with `/devmap mp_rust` (to enable cheats)
2. Type `cg_draw2D 0` into console
3. See the 2D HUD once again can be disabled