### PR TITLE
Fix access violation in AimAssist_ApplyAutoMelee

### DIFF
--- a/src/Game/Functions.cpp
+++ b/src/Game/Functions.cpp
@@ -233,7 +233,6 @@ namespace Game
 
 	Field_Draw_t Field_Draw = Field_Draw_t(0x4F5B40);
 	Field_AdjustScroll_t Field_AdjustScroll = Field_AdjustScroll_t(0x488C10);
-	AimAssist_ApplyAutoMelee_t AimAssist_ApplyAutoMelee = AimAssist_ApplyAutoMelee_t(0x56A360);
 
 	Weapon_RocketLauncher_Fire_t Weapon_RocketLauncher_Fire = Weapon_RocketLauncher_Fire_t(0x424680);
 	Bullet_Fire_t Bullet_Fire = Bullet_Fire_t(0x4402C0);
@@ -1173,6 +1172,24 @@ namespace Game
 			mov eax, [esp + 0x4]
 			mov ebx, 0x569AA0
 			call ebx
+			retn
+		}
+	}
+
+	// Was a plain stack-arg (cdecl) function pointer, crashing on entry (0xC0000005 @
+	// func+0x18) because the real function takes both args in registers, same as its
+	// AimAssist_Update* siblings above. Confirmed against a crash dump: the fault was a
+	// WRITE to 0x569AA8, i.e. output+8 (AimOutput::meleeChargeYaw) using the stale EBX
+	// left over from AimAssist_UpdateAdsLerp's own "mov ebx, 0x569AA0" trampoline just
+	// above - proving the real function reads its output pointer from ebx, not ecx.
+	__declspec(naked) void AimAssist_ApplyAutoMelee(const AimInput* /*input*/, AimOutput* /*output*/)
+	{
+		__asm
+		{
+			mov eax, [esp + 0x4]
+			mov ebx, [esp + 0x8]
+			mov edx, 0x56A360
+			call edx
 			retn
 		}
 	}

--- a/src/Game/Functions.hpp
+++ b/src/Game/Functions.hpp
@@ -557,9 +557,6 @@ namespace Game
 	typedef void(*Field_AdjustScroll_t)(ScreenPlacement* scrPlace, field_t* edit);
 	extern Field_AdjustScroll_t Field_AdjustScroll;
 
-	typedef void(*AimAssist_ApplyAutoMelee_t)(const AimInput* input, AimOutput* output);
-	extern AimAssist_ApplyAutoMelee_t AimAssist_ApplyAutoMelee;
-
 	typedef gentity_s*(*Weapon_RocketLauncher_Fire_t)(gentity_s* ent, unsigned int weaponIndex, float spread, weaponParms* wp, const float* gunVel, lockonFireParms* lockParms, bool magicBullet);
 	extern Weapon_RocketLauncher_Fire_t Weapon_RocketLauncher_Fire;
 
@@ -862,6 +859,7 @@ namespace Game
 
 	void AimAssist_UpdateTweakables(int localClientNum);
 	void AimAssist_UpdateAdsLerp(const AimInput* input);
+	void AimAssist_ApplyAutoMelee(const AimInput* input, AimOutput* output);
 
 	bool ApplyTokenToField(unsigned int fieldNum, const char* token, visionSetVars_t* settings);
 


### PR DESCRIPTION
Fixes #403

## Root Cause

Commit f55d2874 ("Backport x64 controller subsystem to x86") bound `AimAssist_ApplyAutoMelee` as a plain stack-argument function pointer:

```cpp
AimAssist_ApplyAutoMelee_t AimAssist_ApplyAutoMelee = AimAssist_ApplyAutoMelee_t(0x56A360);
```

Its two sibling functions, added in the same commit, are correctly implemented as register-passing naked trampolines, because the underlying binary expects arguments in registers rather than on the stack:

```cpp
__declspec(naked) void AimAssist_UpdateAdsLerp(const AimInput* aimInput)
{
    __asm { mov eax, [esp+0x4]  mov ebx, 0x569AA0  call ebx  retn }
}
```

`AimAssist_ApplyAutoMelee` was left as a plain function pointer. Calling it with pushed stack arguments leaves its real register arguments holding whatever was left over from the prior call, and the function dereferences that garbage.

## Evidence

Two crash dumps show the identical fault: a WRITE to `0x569AA8`. That is `0x569AA0 + 8`, the exact address `AimAssist_UpdateAdsLerp` loads into EBX (callee-saved) one call earlier, plus 8, the offset of `AimOutput::meleeChargeYaw`. This confirms the real function reads its output pointer from EBX, which the old binding never set.

## Fix

Converted to a naked trampoline, input in EAX, output in EBX:

```cpp
__declspec(naked) void AimAssist_ApplyAutoMelee(const AimInput* input, AimOutput* output)
{
    __asm
    {
        mov eax, [esp + 0x4]
        mov ebx, [esp + 0x8]
        mov edx, 0x56A360
        call edx
        retn
    }
}
```

## Verification

Builds clean in Debug and Release (Win32, MSBuild, no warnings). Release build installed in place of the previous `iw4x.dll` and tested live: private Deathmatch on `mp_terminal`, crashed on load before the fix, loads and runs normally after.
